### PR TITLE
Expose `_CurrencyImplementation` as `CurrencyProtocol`

### DIFF
--- a/Sources/Currency/CurrencyProtocol.swift
+++ b/Sources/Currency/CurrencyProtocol.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Currency open source project
+//
+// Copyright (c) 2020 Currency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Currency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Represents a type that acts as a currency.
+///
+/// Any `CurrencyProtocol` type behaves exactly like an `AnyCurrency` type, while also providing other capabilities such as
+/// `Comparable`, `Hashable`, etc.
+///
+/// This is the type to work with in most generic cases, as `AnyCurrency` is a type-erasure protocol when existentials are needed.
+public protocol CurrencyProtocol: AnyCurrency,
+  Comparable, Hashable,
+  ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral,
+  AdditiveArithmetic
+{ }

--- a/Sources/Currency/ISOCurrencies.swift
+++ b/Sources/Currency/ISOCurrencies.swift
@@ -12,24 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Decimal
-
-/// This is a "private" protocol for conforming all ISO 4217 defined currencies to a list of different protocols.
-/// - Warning: Do not conform any type to this protocol, nor use it as a type constraint.
-///
-/// Breaking changes to this **will** be allowed outside of major semver changes.
-public protocol _CurrencyImplementation: AnyCurrency, CurrencyMetadata,
-  Comparable, Hashable,
-  ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral,
-  AdditiveArithmetic { }
-
 // Contents following this line are automatically generated, and should not be edited.
 
 // MARK: -
 // MARK: ISO 4217 Currencies
 
-/// The UAE Dirham (AED).
-public struct AED: _CurrencyImplementation {
+/// The UAE Dirham (AED) currency, as defined by ISO 4217.
+public struct AED: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "UAE Dirham" }
   public static var alphabeticCode: String { return "AED" }
   public static var numericCode: UInt16 { return 784 }
@@ -42,8 +31,8 @@ public struct AED: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Afghani (AFN).
-public struct AFN: _CurrencyImplementation {
+/// The Afghani (AFN) currency, as defined by ISO 4217.
+public struct AFN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Afghani" }
   public static var alphabeticCode: String { return "AFN" }
   public static var numericCode: UInt16 { return 971 }
@@ -56,8 +45,8 @@ public struct AFN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Lek (ALL).
-public struct ALL: _CurrencyImplementation {
+/// The Lek (ALL) currency, as defined by ISO 4217.
+public struct ALL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Lek" }
   public static var alphabeticCode: String { return "ALL" }
   public static var numericCode: UInt16 { return 8 }
@@ -70,8 +59,8 @@ public struct ALL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Armenian Dram (AMD).
-public struct AMD: _CurrencyImplementation {
+/// The Armenian Dram (AMD) currency, as defined by ISO 4217.
+public struct AMD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Armenian Dram" }
   public static var alphabeticCode: String { return "AMD" }
   public static var numericCode: UInt16 { return 51 }
@@ -84,8 +73,8 @@ public struct AMD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Netherlands Antillean Guilder (ANG).
-public struct ANG: _CurrencyImplementation {
+/// The Netherlands Antillean Guilder (ANG) currency, as defined by ISO 4217.
+public struct ANG: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Netherlands Antillean Guilder" }
   public static var alphabeticCode: String { return "ANG" }
   public static var numericCode: UInt16 { return 532 }
@@ -98,8 +87,8 @@ public struct ANG: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Kwanza (AOA).
-public struct AOA: _CurrencyImplementation {
+/// The Kwanza (AOA) currency, as defined by ISO 4217.
+public struct AOA: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Kwanza" }
   public static var alphabeticCode: String { return "AOA" }
   public static var numericCode: UInt16 { return 973 }
@@ -112,8 +101,8 @@ public struct AOA: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Argentine Peso (ARS).
-public struct ARS: _CurrencyImplementation {
+/// The Argentine Peso (ARS) currency, as defined by ISO 4217.
+public struct ARS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Argentine Peso" }
   public static var alphabeticCode: String { return "ARS" }
   public static var numericCode: UInt16 { return 32 }
@@ -126,8 +115,8 @@ public struct ARS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Australian Dollar (AUD).
-public struct AUD: _CurrencyImplementation {
+/// The Australian Dollar (AUD) currency, as defined by ISO 4217.
+public struct AUD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Australian Dollar" }
   public static var alphabeticCode: String { return "AUD" }
   public static var numericCode: UInt16 { return 36 }
@@ -140,8 +129,8 @@ public struct AUD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Aruban Florin (AWG).
-public struct AWG: _CurrencyImplementation {
+/// The Aruban Florin (AWG) currency, as defined by ISO 4217.
+public struct AWG: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Aruban Florin" }
   public static var alphabeticCode: String { return "AWG" }
   public static var numericCode: UInt16 { return 533 }
@@ -154,8 +143,8 @@ public struct AWG: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Azerbaijan Manat (AZN).
-public struct AZN: _CurrencyImplementation {
+/// The Azerbaijan Manat (AZN) currency, as defined by ISO 4217.
+public struct AZN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Azerbaijan Manat" }
   public static var alphabeticCode: String { return "AZN" }
   public static var numericCode: UInt16 { return 944 }
@@ -168,8 +157,8 @@ public struct AZN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Convertible Mark (BAM).
-public struct BAM: _CurrencyImplementation {
+/// The Convertible Mark (BAM) currency, as defined by ISO 4217.
+public struct BAM: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Convertible Mark" }
   public static var alphabeticCode: String { return "BAM" }
   public static var numericCode: UInt16 { return 977 }
@@ -182,8 +171,8 @@ public struct BAM: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Barbados Dollar (BBD).
-public struct BBD: _CurrencyImplementation {
+/// The Barbados Dollar (BBD) currency, as defined by ISO 4217.
+public struct BBD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Barbados Dollar" }
   public static var alphabeticCode: String { return "BBD" }
   public static var numericCode: UInt16 { return 52 }
@@ -196,8 +185,8 @@ public struct BBD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Taka (BDT).
-public struct BDT: _CurrencyImplementation {
+/// The Taka (BDT) currency, as defined by ISO 4217.
+public struct BDT: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Taka" }
   public static var alphabeticCode: String { return "BDT" }
   public static var numericCode: UInt16 { return 50 }
@@ -210,8 +199,8 @@ public struct BDT: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Bulgarian Lev (BGN).
-public struct BGN: _CurrencyImplementation {
+/// The Bulgarian Lev (BGN) currency, as defined by ISO 4217.
+public struct BGN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Bulgarian Lev" }
   public static var alphabeticCode: String { return "BGN" }
   public static var numericCode: UInt16 { return 975 }
@@ -224,8 +213,8 @@ public struct BGN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Bahraini Dinar (BHD).
-public struct BHD: _CurrencyImplementation {
+/// The Bahraini Dinar (BHD) currency, as defined by ISO 4217.
+public struct BHD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Bahraini Dinar" }
   public static var alphabeticCode: String { return "BHD" }
   public static var numericCode: UInt16 { return 48 }
@@ -238,8 +227,8 @@ public struct BHD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Burundi Franc (BIF).
-public struct BIF: _CurrencyImplementation {
+/// The Burundi Franc (BIF) currency, as defined by ISO 4217.
+public struct BIF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Burundi Franc" }
   public static var alphabeticCode: String { return "BIF" }
   public static var numericCode: UInt16 { return 108 }
@@ -252,8 +241,8 @@ public struct BIF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Bermudian Dollar (BMD).
-public struct BMD: _CurrencyImplementation {
+/// The Bermudian Dollar (BMD) currency, as defined by ISO 4217.
+public struct BMD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Bermudian Dollar" }
   public static var alphabeticCode: String { return "BMD" }
   public static var numericCode: UInt16 { return 60 }
@@ -266,8 +255,8 @@ public struct BMD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Brunei Dollar (BND).
-public struct BND: _CurrencyImplementation {
+/// The Brunei Dollar (BND) currency, as defined by ISO 4217.
+public struct BND: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Brunei Dollar" }
   public static var alphabeticCode: String { return "BND" }
   public static var numericCode: UInt16 { return 96 }
@@ -280,8 +269,8 @@ public struct BND: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Boliviano (BOB).
-public struct BOB: _CurrencyImplementation {
+/// The Boliviano (BOB) currency, as defined by ISO 4217.
+public struct BOB: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Boliviano" }
   public static var alphabeticCode: String { return "BOB" }
   public static var numericCode: UInt16 { return 68 }
@@ -294,8 +283,8 @@ public struct BOB: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Brazilian Real (BRL).
-public struct BRL: _CurrencyImplementation {
+/// The Brazilian Real (BRL) currency, as defined by ISO 4217.
+public struct BRL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Brazilian Real" }
   public static var alphabeticCode: String { return "BRL" }
   public static var numericCode: UInt16 { return 986 }
@@ -308,8 +297,8 @@ public struct BRL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Bahamian Dollar (BSD).
-public struct BSD: _CurrencyImplementation {
+/// The Bahamian Dollar (BSD) currency, as defined by ISO 4217.
+public struct BSD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Bahamian Dollar" }
   public static var alphabeticCode: String { return "BSD" }
   public static var numericCode: UInt16 { return 44 }
@@ -322,8 +311,8 @@ public struct BSD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Ngultrum (BTN).
-public struct BTN: _CurrencyImplementation {
+/// The Ngultrum (BTN) currency, as defined by ISO 4217.
+public struct BTN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Ngultrum" }
   public static var alphabeticCode: String { return "BTN" }
   public static var numericCode: UInt16 { return 64 }
@@ -336,8 +325,8 @@ public struct BTN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Pula (BWP).
-public struct BWP: _CurrencyImplementation {
+/// The Pula (BWP) currency, as defined by ISO 4217.
+public struct BWP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Pula" }
   public static var alphabeticCode: String { return "BWP" }
   public static var numericCode: UInt16 { return 72 }
@@ -350,8 +339,8 @@ public struct BWP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Belarusian Ruble (BYN).
-public struct BYN: _CurrencyImplementation {
+/// The Belarusian Ruble (BYN) currency, as defined by ISO 4217.
+public struct BYN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Belarusian Ruble" }
   public static var alphabeticCode: String { return "BYN" }
   public static var numericCode: UInt16 { return 933 }
@@ -364,8 +353,8 @@ public struct BYN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Belize Dollar (BZD).
-public struct BZD: _CurrencyImplementation {
+/// The Belize Dollar (BZD) currency, as defined by ISO 4217.
+public struct BZD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Belize Dollar" }
   public static var alphabeticCode: String { return "BZD" }
   public static var numericCode: UInt16 { return 84 }
@@ -378,8 +367,8 @@ public struct BZD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Canadian Dollar (CAD).
-public struct CAD: _CurrencyImplementation {
+/// The Canadian Dollar (CAD) currency, as defined by ISO 4217.
+public struct CAD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Canadian Dollar" }
   public static var alphabeticCode: String { return "CAD" }
   public static var numericCode: UInt16 { return 124 }
@@ -392,8 +381,8 @@ public struct CAD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Congolese Franc (CDF).
-public struct CDF: _CurrencyImplementation {
+/// The Congolese Franc (CDF) currency, as defined by ISO 4217.
+public struct CDF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Congolese Franc" }
   public static var alphabeticCode: String { return "CDF" }
   public static var numericCode: UInt16 { return 976 }
@@ -406,8 +395,8 @@ public struct CDF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Swiss Franc (CHF).
-public struct CHF: _CurrencyImplementation {
+/// The Swiss Franc (CHF) currency, as defined by ISO 4217.
+public struct CHF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Swiss Franc" }
   public static var alphabeticCode: String { return "CHF" }
   public static var numericCode: UInt16 { return 756 }
@@ -420,8 +409,8 @@ public struct CHF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Chilean Peso (CLP).
-public struct CLP: _CurrencyImplementation {
+/// The Chilean Peso (CLP) currency, as defined by ISO 4217.
+public struct CLP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Chilean Peso" }
   public static var alphabeticCode: String { return "CLP" }
   public static var numericCode: UInt16 { return 152 }
@@ -434,8 +423,8 @@ public struct CLP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Yuan Renminbi (CNY).
-public struct CNY: _CurrencyImplementation {
+/// The Yuan Renminbi (CNY) currency, as defined by ISO 4217.
+public struct CNY: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Yuan Renminbi" }
   public static var alphabeticCode: String { return "CNY" }
   public static var numericCode: UInt16 { return 156 }
@@ -448,8 +437,8 @@ public struct CNY: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Colombian Peso (COP).
-public struct COP: _CurrencyImplementation {
+/// The Colombian Peso (COP) currency, as defined by ISO 4217.
+public struct COP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Colombian Peso" }
   public static var alphabeticCode: String { return "COP" }
   public static var numericCode: UInt16 { return 170 }
@@ -462,8 +451,8 @@ public struct COP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Costa Rican Colon (CRC).
-public struct CRC: _CurrencyImplementation {
+/// The Costa Rican Colon (CRC) currency, as defined by ISO 4217.
+public struct CRC: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Costa Rican Colon" }
   public static var alphabeticCode: String { return "CRC" }
   public static var numericCode: UInt16 { return 188 }
@@ -476,8 +465,8 @@ public struct CRC: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Peso Convertible (CUC).
-public struct CUC: _CurrencyImplementation {
+/// The Peso Convertible (CUC) currency, as defined by ISO 4217.
+public struct CUC: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Peso Convertible" }
   public static var alphabeticCode: String { return "CUC" }
   public static var numericCode: UInt16 { return 931 }
@@ -490,8 +479,8 @@ public struct CUC: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Cuban Peso (CUP).
-public struct CUP: _CurrencyImplementation {
+/// The Cuban Peso (CUP) currency, as defined by ISO 4217.
+public struct CUP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Cuban Peso" }
   public static var alphabeticCode: String { return "CUP" }
   public static var numericCode: UInt16 { return 192 }
@@ -504,8 +493,8 @@ public struct CUP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Cabo Verde Escudo (CVE).
-public struct CVE: _CurrencyImplementation {
+/// The Cabo Verde Escudo (CVE) currency, as defined by ISO 4217.
+public struct CVE: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Cabo Verde Escudo" }
   public static var alphabeticCode: String { return "CVE" }
   public static var numericCode: UInt16 { return 132 }
@@ -518,8 +507,8 @@ public struct CVE: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Czech Koruna (CZK).
-public struct CZK: _CurrencyImplementation {
+/// The Czech Koruna (CZK) currency, as defined by ISO 4217.
+public struct CZK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Czech Koruna" }
   public static var alphabeticCode: String { return "CZK" }
   public static var numericCode: UInt16 { return 203 }
@@ -532,8 +521,8 @@ public struct CZK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Djibouti Franc (DJF).
-public struct DJF: _CurrencyImplementation {
+/// The Djibouti Franc (DJF) currency, as defined by ISO 4217.
+public struct DJF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Djibouti Franc" }
   public static var alphabeticCode: String { return "DJF" }
   public static var numericCode: UInt16 { return 262 }
@@ -546,8 +535,8 @@ public struct DJF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Danish Krone (DKK).
-public struct DKK: _CurrencyImplementation {
+/// The Danish Krone (DKK) currency, as defined by ISO 4217.
+public struct DKK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Danish Krone" }
   public static var alphabeticCode: String { return "DKK" }
   public static var numericCode: UInt16 { return 208 }
@@ -560,8 +549,8 @@ public struct DKK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Dominican Peso (DOP).
-public struct DOP: _CurrencyImplementation {
+/// The Dominican Peso (DOP) currency, as defined by ISO 4217.
+public struct DOP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Dominican Peso" }
   public static var alphabeticCode: String { return "DOP" }
   public static var numericCode: UInt16 { return 214 }
@@ -574,8 +563,8 @@ public struct DOP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Algerian Dinar (DZD).
-public struct DZD: _CurrencyImplementation {
+/// The Algerian Dinar (DZD) currency, as defined by ISO 4217.
+public struct DZD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Algerian Dinar" }
   public static var alphabeticCode: String { return "DZD" }
   public static var numericCode: UInt16 { return 12 }
@@ -588,8 +577,8 @@ public struct DZD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Egyptian Pound (EGP).
-public struct EGP: _CurrencyImplementation {
+/// The Egyptian Pound (EGP) currency, as defined by ISO 4217.
+public struct EGP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Egyptian Pound" }
   public static var alphabeticCode: String { return "EGP" }
   public static var numericCode: UInt16 { return 818 }
@@ -602,8 +591,8 @@ public struct EGP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Nakfa (ERN).
-public struct ERN: _CurrencyImplementation {
+/// The Nakfa (ERN) currency, as defined by ISO 4217.
+public struct ERN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Nakfa" }
   public static var alphabeticCode: String { return "ERN" }
   public static var numericCode: UInt16 { return 232 }
@@ -616,8 +605,8 @@ public struct ERN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Ethiopian Birr (ETB).
-public struct ETB: _CurrencyImplementation {
+/// The Ethiopian Birr (ETB) currency, as defined by ISO 4217.
+public struct ETB: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Ethiopian Birr" }
   public static var alphabeticCode: String { return "ETB" }
   public static var numericCode: UInt16 { return 230 }
@@ -630,8 +619,8 @@ public struct ETB: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Euro (EUR).
-public struct EUR: _CurrencyImplementation {
+/// The Euro (EUR) currency, as defined by ISO 4217.
+public struct EUR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Euro" }
   public static var alphabeticCode: String { return "EUR" }
   public static var numericCode: UInt16 { return 978 }
@@ -644,8 +633,8 @@ public struct EUR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Fiji Dollar (FJD).
-public struct FJD: _CurrencyImplementation {
+/// The Fiji Dollar (FJD) currency, as defined by ISO 4217.
+public struct FJD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Fiji Dollar" }
   public static var alphabeticCode: String { return "FJD" }
   public static var numericCode: UInt16 { return 242 }
@@ -658,8 +647,8 @@ public struct FJD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Falkland Islands Pound (FKP).
-public struct FKP: _CurrencyImplementation {
+/// The Falkland Islands Pound (FKP) currency, as defined by ISO 4217.
+public struct FKP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Falkland Islands Pound" }
   public static var alphabeticCode: String { return "FKP" }
   public static var numericCode: UInt16 { return 238 }
@@ -672,8 +661,8 @@ public struct FKP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Pound Sterling (GBP).
-public struct GBP: _CurrencyImplementation {
+/// The Pound Sterling (GBP) currency, as defined by ISO 4217.
+public struct GBP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Pound Sterling" }
   public static var alphabeticCode: String { return "GBP" }
   public static var numericCode: UInt16 { return 826 }
@@ -686,8 +675,8 @@ public struct GBP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Lari (GEL).
-public struct GEL: _CurrencyImplementation {
+/// The Lari (GEL) currency, as defined by ISO 4217.
+public struct GEL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Lari" }
   public static var alphabeticCode: String { return "GEL" }
   public static var numericCode: UInt16 { return 981 }
@@ -700,8 +689,8 @@ public struct GEL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Ghana Cedi (GHS).
-public struct GHS: _CurrencyImplementation {
+/// The Ghana Cedi (GHS) currency, as defined by ISO 4217.
+public struct GHS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Ghana Cedi" }
   public static var alphabeticCode: String { return "GHS" }
   public static var numericCode: UInt16 { return 936 }
@@ -714,8 +703,8 @@ public struct GHS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Gibraltar Pound (GIP).
-public struct GIP: _CurrencyImplementation {
+/// The Gibraltar Pound (GIP) currency, as defined by ISO 4217.
+public struct GIP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Gibraltar Pound" }
   public static var alphabeticCode: String { return "GIP" }
   public static var numericCode: UInt16 { return 292 }
@@ -728,8 +717,8 @@ public struct GIP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Dalasi (GMD).
-public struct GMD: _CurrencyImplementation {
+/// The Dalasi (GMD) currency, as defined by ISO 4217.
+public struct GMD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Dalasi" }
   public static var alphabeticCode: String { return "GMD" }
   public static var numericCode: UInt16 { return 270 }
@@ -742,8 +731,8 @@ public struct GMD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Guinean Franc (GNF).
-public struct GNF: _CurrencyImplementation {
+/// The Guinean Franc (GNF) currency, as defined by ISO 4217.
+public struct GNF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Guinean Franc" }
   public static var alphabeticCode: String { return "GNF" }
   public static var numericCode: UInt16 { return 324 }
@@ -756,8 +745,8 @@ public struct GNF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Quetzal (GTQ).
-public struct GTQ: _CurrencyImplementation {
+/// The Quetzal (GTQ) currency, as defined by ISO 4217.
+public struct GTQ: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Quetzal" }
   public static var alphabeticCode: String { return "GTQ" }
   public static var numericCode: UInt16 { return 320 }
@@ -770,8 +759,8 @@ public struct GTQ: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Guyana Dollar (GYD).
-public struct GYD: _CurrencyImplementation {
+/// The Guyana Dollar (GYD) currency, as defined by ISO 4217.
+public struct GYD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Guyana Dollar" }
   public static var alphabeticCode: String { return "GYD" }
   public static var numericCode: UInt16 { return 328 }
@@ -784,8 +773,8 @@ public struct GYD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Hong Kong Dollar (HKD).
-public struct HKD: _CurrencyImplementation {
+/// The Hong Kong Dollar (HKD) currency, as defined by ISO 4217.
+public struct HKD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Hong Kong Dollar" }
   public static var alphabeticCode: String { return "HKD" }
   public static var numericCode: UInt16 { return 344 }
@@ -798,8 +787,8 @@ public struct HKD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Lempira (HNL).
-public struct HNL: _CurrencyImplementation {
+/// The Lempira (HNL) currency, as defined by ISO 4217.
+public struct HNL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Lempira" }
   public static var alphabeticCode: String { return "HNL" }
   public static var numericCode: UInt16 { return 340 }
@@ -812,8 +801,8 @@ public struct HNL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Kuna (HRK).
-public struct HRK: _CurrencyImplementation {
+/// The Kuna (HRK) currency, as defined by ISO 4217.
+public struct HRK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Kuna" }
   public static var alphabeticCode: String { return "HRK" }
   public static var numericCode: UInt16 { return 191 }
@@ -826,8 +815,8 @@ public struct HRK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Gourde (HTG).
-public struct HTG: _CurrencyImplementation {
+/// The Gourde (HTG) currency, as defined by ISO 4217.
+public struct HTG: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Gourde" }
   public static var alphabeticCode: String { return "HTG" }
   public static var numericCode: UInt16 { return 332 }
@@ -840,8 +829,8 @@ public struct HTG: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Forint (HUF).
-public struct HUF: _CurrencyImplementation {
+/// The Forint (HUF) currency, as defined by ISO 4217.
+public struct HUF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Forint" }
   public static var alphabeticCode: String { return "HUF" }
   public static var numericCode: UInt16 { return 348 }
@@ -854,8 +843,8 @@ public struct HUF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Rupiah (IDR).
-public struct IDR: _CurrencyImplementation {
+/// The Rupiah (IDR) currency, as defined by ISO 4217.
+public struct IDR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Rupiah" }
   public static var alphabeticCode: String { return "IDR" }
   public static var numericCode: UInt16 { return 360 }
@@ -868,8 +857,8 @@ public struct IDR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The New Israeli Sheqel (ILS).
-public struct ILS: _CurrencyImplementation {
+/// The New Israeli Sheqel (ILS) currency, as defined by ISO 4217.
+public struct ILS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "New Israeli Sheqel" }
   public static var alphabeticCode: String { return "ILS" }
   public static var numericCode: UInt16 { return 376 }
@@ -882,8 +871,8 @@ public struct ILS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Indian Rupee (INR).
-public struct INR: _CurrencyImplementation {
+/// The Indian Rupee (INR) currency, as defined by ISO 4217.
+public struct INR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Indian Rupee" }
   public static var alphabeticCode: String { return "INR" }
   public static var numericCode: UInt16 { return 356 }
@@ -896,8 +885,8 @@ public struct INR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Iraqi Dinar (IQD).
-public struct IQD: _CurrencyImplementation {
+/// The Iraqi Dinar (IQD) currency, as defined by ISO 4217.
+public struct IQD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Iraqi Dinar" }
   public static var alphabeticCode: String { return "IQD" }
   public static var numericCode: UInt16 { return 368 }
@@ -910,8 +899,8 @@ public struct IQD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Iranian Rial (IRR).
-public struct IRR: _CurrencyImplementation {
+/// The Iranian Rial (IRR) currency, as defined by ISO 4217.
+public struct IRR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Iranian Rial" }
   public static var alphabeticCode: String { return "IRR" }
   public static var numericCode: UInt16 { return 364 }
@@ -924,8 +913,8 @@ public struct IRR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Iceland Krona (ISK).
-public struct ISK: _CurrencyImplementation {
+/// The Iceland Krona (ISK) currency, as defined by ISO 4217.
+public struct ISK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Iceland Krona" }
   public static var alphabeticCode: String { return "ISK" }
   public static var numericCode: UInt16 { return 352 }
@@ -938,8 +927,8 @@ public struct ISK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Jamaican Dollar (JMD).
-public struct JMD: _CurrencyImplementation {
+/// The Jamaican Dollar (JMD) currency, as defined by ISO 4217.
+public struct JMD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Jamaican Dollar" }
   public static var alphabeticCode: String { return "JMD" }
   public static var numericCode: UInt16 { return 388 }
@@ -952,8 +941,8 @@ public struct JMD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Jordanian Dinar (JOD).
-public struct JOD: _CurrencyImplementation {
+/// The Jordanian Dinar (JOD) currency, as defined by ISO 4217.
+public struct JOD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Jordanian Dinar" }
   public static var alphabeticCode: String { return "JOD" }
   public static var numericCode: UInt16 { return 400 }
@@ -966,8 +955,8 @@ public struct JOD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Yen (JPY).
-public struct JPY: _CurrencyImplementation {
+/// The Yen (JPY) currency, as defined by ISO 4217.
+public struct JPY: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Yen" }
   public static var alphabeticCode: String { return "JPY" }
   public static var numericCode: UInt16 { return 392 }
@@ -980,8 +969,8 @@ public struct JPY: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Kenyan Shilling (KES).
-public struct KES: _CurrencyImplementation {
+/// The Kenyan Shilling (KES) currency, as defined by ISO 4217.
+public struct KES: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Kenyan Shilling" }
   public static var alphabeticCode: String { return "KES" }
   public static var numericCode: UInt16 { return 404 }
@@ -994,8 +983,8 @@ public struct KES: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Som (KGS).
-public struct KGS: _CurrencyImplementation {
+/// The Som (KGS) currency, as defined by ISO 4217.
+public struct KGS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Som" }
   public static var alphabeticCode: String { return "KGS" }
   public static var numericCode: UInt16 { return 417 }
@@ -1008,8 +997,8 @@ public struct KGS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Riel (KHR).
-public struct KHR: _CurrencyImplementation {
+/// The Riel (KHR) currency, as defined by ISO 4217.
+public struct KHR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Riel" }
   public static var alphabeticCode: String { return "KHR" }
   public static var numericCode: UInt16 { return 116 }
@@ -1022,8 +1011,8 @@ public struct KHR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Comorian Franc (KMF).
-public struct KMF: _CurrencyImplementation {
+/// The Comorian Franc (KMF) currency, as defined by ISO 4217.
+public struct KMF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Comorian Franc" }
   public static var alphabeticCode: String { return "KMF" }
   public static var numericCode: UInt16 { return 174 }
@@ -1036,8 +1025,8 @@ public struct KMF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The North Korean Won (KPW).
-public struct KPW: _CurrencyImplementation {
+/// The North Korean Won (KPW) currency, as defined by ISO 4217.
+public struct KPW: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "North Korean Won" }
   public static var alphabeticCode: String { return "KPW" }
   public static var numericCode: UInt16 { return 408 }
@@ -1050,8 +1039,8 @@ public struct KPW: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Won (KRW).
-public struct KRW: _CurrencyImplementation {
+/// The Won (KRW) currency, as defined by ISO 4217.
+public struct KRW: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Won" }
   public static var alphabeticCode: String { return "KRW" }
   public static var numericCode: UInt16 { return 410 }
@@ -1064,8 +1053,8 @@ public struct KRW: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Kuwaiti Dinar (KWD).
-public struct KWD: _CurrencyImplementation {
+/// The Kuwaiti Dinar (KWD) currency, as defined by ISO 4217.
+public struct KWD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Kuwaiti Dinar" }
   public static var alphabeticCode: String { return "KWD" }
   public static var numericCode: UInt16 { return 414 }
@@ -1078,8 +1067,8 @@ public struct KWD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Cayman Islands Dollar (KYD).
-public struct KYD: _CurrencyImplementation {
+/// The Cayman Islands Dollar (KYD) currency, as defined by ISO 4217.
+public struct KYD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Cayman Islands Dollar" }
   public static var alphabeticCode: String { return "KYD" }
   public static var numericCode: UInt16 { return 136 }
@@ -1092,8 +1081,8 @@ public struct KYD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Tenge (KZT).
-public struct KZT: _CurrencyImplementation {
+/// The Tenge (KZT) currency, as defined by ISO 4217.
+public struct KZT: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Tenge" }
   public static var alphabeticCode: String { return "KZT" }
   public static var numericCode: UInt16 { return 398 }
@@ -1106,8 +1095,8 @@ public struct KZT: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Lao Kip (LAK).
-public struct LAK: _CurrencyImplementation {
+/// The Lao Kip (LAK) currency, as defined by ISO 4217.
+public struct LAK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Lao Kip" }
   public static var alphabeticCode: String { return "LAK" }
   public static var numericCode: UInt16 { return 418 }
@@ -1120,8 +1109,8 @@ public struct LAK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Lebanese Pound (LBP).
-public struct LBP: _CurrencyImplementation {
+/// The Lebanese Pound (LBP) currency, as defined by ISO 4217.
+public struct LBP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Lebanese Pound" }
   public static var alphabeticCode: String { return "LBP" }
   public static var numericCode: UInt16 { return 422 }
@@ -1134,8 +1123,8 @@ public struct LBP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Sri Lanka Rupee (LKR).
-public struct LKR: _CurrencyImplementation {
+/// The Sri Lanka Rupee (LKR) currency, as defined by ISO 4217.
+public struct LKR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Sri Lanka Rupee" }
   public static var alphabeticCode: String { return "LKR" }
   public static var numericCode: UInt16 { return 144 }
@@ -1148,8 +1137,8 @@ public struct LKR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Liberian Dollar (LRD).
-public struct LRD: _CurrencyImplementation {
+/// The Liberian Dollar (LRD) currency, as defined by ISO 4217.
+public struct LRD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Liberian Dollar" }
   public static var alphabeticCode: String { return "LRD" }
   public static var numericCode: UInt16 { return 430 }
@@ -1162,8 +1151,8 @@ public struct LRD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Loti (LSL).
-public struct LSL: _CurrencyImplementation {
+/// The Loti (LSL) currency, as defined by ISO 4217.
+public struct LSL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Loti" }
   public static var alphabeticCode: String { return "LSL" }
   public static var numericCode: UInt16 { return 426 }
@@ -1176,8 +1165,8 @@ public struct LSL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Libyan Dinar (LYD).
-public struct LYD: _CurrencyImplementation {
+/// The Libyan Dinar (LYD) currency, as defined by ISO 4217.
+public struct LYD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Libyan Dinar" }
   public static var alphabeticCode: String { return "LYD" }
   public static var numericCode: UInt16 { return 434 }
@@ -1190,8 +1179,8 @@ public struct LYD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Moroccan Dirham (MAD).
-public struct MAD: _CurrencyImplementation {
+/// The Moroccan Dirham (MAD) currency, as defined by ISO 4217.
+public struct MAD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Moroccan Dirham" }
   public static var alphabeticCode: String { return "MAD" }
   public static var numericCode: UInt16 { return 504 }
@@ -1204,8 +1193,8 @@ public struct MAD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Moldovan Leu (MDL).
-public struct MDL: _CurrencyImplementation {
+/// The Moldovan Leu (MDL) currency, as defined by ISO 4217.
+public struct MDL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Moldovan Leu" }
   public static var alphabeticCode: String { return "MDL" }
   public static var numericCode: UInt16 { return 498 }
@@ -1218,8 +1207,8 @@ public struct MDL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Malagasy Ariary (MGA).
-public struct MGA: _CurrencyImplementation {
+/// The Malagasy Ariary (MGA) currency, as defined by ISO 4217.
+public struct MGA: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Malagasy Ariary" }
   public static var alphabeticCode: String { return "MGA" }
   public static var numericCode: UInt16 { return 969 }
@@ -1232,8 +1221,8 @@ public struct MGA: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Denar (MKD).
-public struct MKD: _CurrencyImplementation {
+/// The Denar (MKD) currency, as defined by ISO 4217.
+public struct MKD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Denar" }
   public static var alphabeticCode: String { return "MKD" }
   public static var numericCode: UInt16 { return 807 }
@@ -1246,8 +1235,8 @@ public struct MKD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Kyat (MMK).
-public struct MMK: _CurrencyImplementation {
+/// The Kyat (MMK) currency, as defined by ISO 4217.
+public struct MMK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Kyat" }
   public static var alphabeticCode: String { return "MMK" }
   public static var numericCode: UInt16 { return 104 }
@@ -1260,8 +1249,8 @@ public struct MMK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Tugrik (MNT).
-public struct MNT: _CurrencyImplementation {
+/// The Tugrik (MNT) currency, as defined by ISO 4217.
+public struct MNT: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Tugrik" }
   public static var alphabeticCode: String { return "MNT" }
   public static var numericCode: UInt16 { return 496 }
@@ -1274,8 +1263,8 @@ public struct MNT: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Pataca (MOP).
-public struct MOP: _CurrencyImplementation {
+/// The Pataca (MOP) currency, as defined by ISO 4217.
+public struct MOP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Pataca" }
   public static var alphabeticCode: String { return "MOP" }
   public static var numericCode: UInt16 { return 446 }
@@ -1288,8 +1277,8 @@ public struct MOP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Ouguiya (MRU).
-public struct MRU: _CurrencyImplementation {
+/// The Ouguiya (MRU) currency, as defined by ISO 4217.
+public struct MRU: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Ouguiya" }
   public static var alphabeticCode: String { return "MRU" }
   public static var numericCode: UInt16 { return 929 }
@@ -1302,8 +1291,8 @@ public struct MRU: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Mauritius Rupee (MUR).
-public struct MUR: _CurrencyImplementation {
+/// The Mauritius Rupee (MUR) currency, as defined by ISO 4217.
+public struct MUR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Mauritius Rupee" }
   public static var alphabeticCode: String { return "MUR" }
   public static var numericCode: UInt16 { return 480 }
@@ -1316,8 +1305,8 @@ public struct MUR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Rufiyaa (MVR).
-public struct MVR: _CurrencyImplementation {
+/// The Rufiyaa (MVR) currency, as defined by ISO 4217.
+public struct MVR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Rufiyaa" }
   public static var alphabeticCode: String { return "MVR" }
   public static var numericCode: UInt16 { return 462 }
@@ -1330,8 +1319,8 @@ public struct MVR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Malawi Kwacha (MWK).
-public struct MWK: _CurrencyImplementation {
+/// The Malawi Kwacha (MWK) currency, as defined by ISO 4217.
+public struct MWK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Malawi Kwacha" }
   public static var alphabeticCode: String { return "MWK" }
   public static var numericCode: UInt16 { return 454 }
@@ -1344,8 +1333,8 @@ public struct MWK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Mexican Peso (MXN).
-public struct MXN: _CurrencyImplementation {
+/// The Mexican Peso (MXN) currency, as defined by ISO 4217.
+public struct MXN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Mexican Peso" }
   public static var alphabeticCode: String { return "MXN" }
   public static var numericCode: UInt16 { return 484 }
@@ -1358,8 +1347,8 @@ public struct MXN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Malaysian Ringgit (MYR).
-public struct MYR: _CurrencyImplementation {
+/// The Malaysian Ringgit (MYR) currency, as defined by ISO 4217.
+public struct MYR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Malaysian Ringgit" }
   public static var alphabeticCode: String { return "MYR" }
   public static var numericCode: UInt16 { return 458 }
@@ -1372,8 +1361,8 @@ public struct MYR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Mozambique Metical (MZN).
-public struct MZN: _CurrencyImplementation {
+/// The Mozambique Metical (MZN) currency, as defined by ISO 4217.
+public struct MZN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Mozambique Metical" }
   public static var alphabeticCode: String { return "MZN" }
   public static var numericCode: UInt16 { return 943 }
@@ -1386,8 +1375,8 @@ public struct MZN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Namibia Dollar (NAD).
-public struct NAD: _CurrencyImplementation {
+/// The Namibia Dollar (NAD) currency, as defined by ISO 4217.
+public struct NAD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Namibia Dollar" }
   public static var alphabeticCode: String { return "NAD" }
   public static var numericCode: UInt16 { return 516 }
@@ -1400,8 +1389,8 @@ public struct NAD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Naira (NGN).
-public struct NGN: _CurrencyImplementation {
+/// The Naira (NGN) currency, as defined by ISO 4217.
+public struct NGN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Naira" }
   public static var alphabeticCode: String { return "NGN" }
   public static var numericCode: UInt16 { return 566 }
@@ -1414,8 +1403,8 @@ public struct NGN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Cordoba Oro (NIO).
-public struct NIO: _CurrencyImplementation {
+/// The Cordoba Oro (NIO) currency, as defined by ISO 4217.
+public struct NIO: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Cordoba Oro" }
   public static var alphabeticCode: String { return "NIO" }
   public static var numericCode: UInt16 { return 558 }
@@ -1428,8 +1417,8 @@ public struct NIO: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Norwegian Krone (NOK).
-public struct NOK: _CurrencyImplementation {
+/// The Norwegian Krone (NOK) currency, as defined by ISO 4217.
+public struct NOK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Norwegian Krone" }
   public static var alphabeticCode: String { return "NOK" }
   public static var numericCode: UInt16 { return 578 }
@@ -1442,8 +1431,8 @@ public struct NOK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Nepalese Rupee (NPR).
-public struct NPR: _CurrencyImplementation {
+/// The Nepalese Rupee (NPR) currency, as defined by ISO 4217.
+public struct NPR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Nepalese Rupee" }
   public static var alphabeticCode: String { return "NPR" }
   public static var numericCode: UInt16 { return 524 }
@@ -1456,8 +1445,8 @@ public struct NPR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The New Zealand Dollar (NZD).
-public struct NZD: _CurrencyImplementation {
+/// The New Zealand Dollar (NZD) currency, as defined by ISO 4217.
+public struct NZD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "New Zealand Dollar" }
   public static var alphabeticCode: String { return "NZD" }
   public static var numericCode: UInt16 { return 554 }
@@ -1470,8 +1459,8 @@ public struct NZD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Rial Omani (OMR).
-public struct OMR: _CurrencyImplementation {
+/// The Rial Omani (OMR) currency, as defined by ISO 4217.
+public struct OMR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Rial Omani" }
   public static var alphabeticCode: String { return "OMR" }
   public static var numericCode: UInt16 { return 512 }
@@ -1484,8 +1473,8 @@ public struct OMR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Balboa (PAB).
-public struct PAB: _CurrencyImplementation {
+/// The Balboa (PAB) currency, as defined by ISO 4217.
+public struct PAB: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Balboa" }
   public static var alphabeticCode: String { return "PAB" }
   public static var numericCode: UInt16 { return 590 }
@@ -1498,8 +1487,8 @@ public struct PAB: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Sol (PEN).
-public struct PEN: _CurrencyImplementation {
+/// The Sol (PEN) currency, as defined by ISO 4217.
+public struct PEN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Sol" }
   public static var alphabeticCode: String { return "PEN" }
   public static var numericCode: UInt16 { return 604 }
@@ -1512,8 +1501,8 @@ public struct PEN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Kina (PGK).
-public struct PGK: _CurrencyImplementation {
+/// The Kina (PGK) currency, as defined by ISO 4217.
+public struct PGK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Kina" }
   public static var alphabeticCode: String { return "PGK" }
   public static var numericCode: UInt16 { return 598 }
@@ -1526,8 +1515,8 @@ public struct PGK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Philippine Peso (PHP).
-public struct PHP: _CurrencyImplementation {
+/// The Philippine Peso (PHP) currency, as defined by ISO 4217.
+public struct PHP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Philippine Peso" }
   public static var alphabeticCode: String { return "PHP" }
   public static var numericCode: UInt16 { return 608 }
@@ -1540,8 +1529,8 @@ public struct PHP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Pakistan Rupee (PKR).
-public struct PKR: _CurrencyImplementation {
+/// The Pakistan Rupee (PKR) currency, as defined by ISO 4217.
+public struct PKR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Pakistan Rupee" }
   public static var alphabeticCode: String { return "PKR" }
   public static var numericCode: UInt16 { return 586 }
@@ -1554,8 +1543,8 @@ public struct PKR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Zloty (PLN).
-public struct PLN: _CurrencyImplementation {
+/// The Zloty (PLN) currency, as defined by ISO 4217.
+public struct PLN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Zloty" }
   public static var alphabeticCode: String { return "PLN" }
   public static var numericCode: UInt16 { return 985 }
@@ -1568,8 +1557,8 @@ public struct PLN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Guarani (PYG).
-public struct PYG: _CurrencyImplementation {
+/// The Guarani (PYG) currency, as defined by ISO 4217.
+public struct PYG: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Guarani" }
   public static var alphabeticCode: String { return "PYG" }
   public static var numericCode: UInt16 { return 600 }
@@ -1582,8 +1571,8 @@ public struct PYG: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Qatari Rial (QAR).
-public struct QAR: _CurrencyImplementation {
+/// The Qatari Rial (QAR) currency, as defined by ISO 4217.
+public struct QAR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Qatari Rial" }
   public static var alphabeticCode: String { return "QAR" }
   public static var numericCode: UInt16 { return 634 }
@@ -1596,8 +1585,8 @@ public struct QAR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Romanian Leu (RON).
-public struct RON: _CurrencyImplementation {
+/// The Romanian Leu (RON) currency, as defined by ISO 4217.
+public struct RON: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Romanian Leu" }
   public static var alphabeticCode: String { return "RON" }
   public static var numericCode: UInt16 { return 946 }
@@ -1610,8 +1599,8 @@ public struct RON: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Serbian Dinar (RSD).
-public struct RSD: _CurrencyImplementation {
+/// The Serbian Dinar (RSD) currency, as defined by ISO 4217.
+public struct RSD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Serbian Dinar" }
   public static var alphabeticCode: String { return "RSD" }
   public static var numericCode: UInt16 { return 941 }
@@ -1624,8 +1613,8 @@ public struct RSD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Russian Ruble (RUB).
-public struct RUB: _CurrencyImplementation {
+/// The Russian Ruble (RUB) currency, as defined by ISO 4217.
+public struct RUB: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Russian Ruble" }
   public static var alphabeticCode: String { return "RUB" }
   public static var numericCode: UInt16 { return 643 }
@@ -1638,8 +1627,8 @@ public struct RUB: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Rwanda Franc (RWF).
-public struct RWF: _CurrencyImplementation {
+/// The Rwanda Franc (RWF) currency, as defined by ISO 4217.
+public struct RWF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Rwanda Franc" }
   public static var alphabeticCode: String { return "RWF" }
   public static var numericCode: UInt16 { return 646 }
@@ -1652,8 +1641,8 @@ public struct RWF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Saudi Riyal (SAR).
-public struct SAR: _CurrencyImplementation {
+/// The Saudi Riyal (SAR) currency, as defined by ISO 4217.
+public struct SAR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Saudi Riyal" }
   public static var alphabeticCode: String { return "SAR" }
   public static var numericCode: UInt16 { return 682 }
@@ -1666,8 +1655,8 @@ public struct SAR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Solomon Islands Dollar (SBD).
-public struct SBD: _CurrencyImplementation {
+/// The Solomon Islands Dollar (SBD) currency, as defined by ISO 4217.
+public struct SBD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Solomon Islands Dollar" }
   public static var alphabeticCode: String { return "SBD" }
   public static var numericCode: UInt16 { return 90 }
@@ -1680,8 +1669,8 @@ public struct SBD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Seychelles Rupee (SCR).
-public struct SCR: _CurrencyImplementation {
+/// The Seychelles Rupee (SCR) currency, as defined by ISO 4217.
+public struct SCR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Seychelles Rupee" }
   public static var alphabeticCode: String { return "SCR" }
   public static var numericCode: UInt16 { return 690 }
@@ -1694,8 +1683,8 @@ public struct SCR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Sudanese Pound (SDG).
-public struct SDG: _CurrencyImplementation {
+/// The Sudanese Pound (SDG) currency, as defined by ISO 4217.
+public struct SDG: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Sudanese Pound" }
   public static var alphabeticCode: String { return "SDG" }
   public static var numericCode: UInt16 { return 938 }
@@ -1708,8 +1697,8 @@ public struct SDG: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Swedish Krona (SEK).
-public struct SEK: _CurrencyImplementation {
+/// The Swedish Krona (SEK) currency, as defined by ISO 4217.
+public struct SEK: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Swedish Krona" }
   public static var alphabeticCode: String { return "SEK" }
   public static var numericCode: UInt16 { return 752 }
@@ -1722,8 +1711,8 @@ public struct SEK: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Singapore Dollar (SGD).
-public struct SGD: _CurrencyImplementation {
+/// The Singapore Dollar (SGD) currency, as defined by ISO 4217.
+public struct SGD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Singapore Dollar" }
   public static var alphabeticCode: String { return "SGD" }
   public static var numericCode: UInt16 { return 702 }
@@ -1736,8 +1725,8 @@ public struct SGD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Saint Helena Pound (SHP).
-public struct SHP: _CurrencyImplementation {
+/// The Saint Helena Pound (SHP) currency, as defined by ISO 4217.
+public struct SHP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Saint Helena Pound" }
   public static var alphabeticCode: String { return "SHP" }
   public static var numericCode: UInt16 { return 654 }
@@ -1750,8 +1739,8 @@ public struct SHP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Leone (SLL).
-public struct SLL: _CurrencyImplementation {
+/// The Leone (SLL) currency, as defined by ISO 4217.
+public struct SLL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Leone" }
   public static var alphabeticCode: String { return "SLL" }
   public static var numericCode: UInt16 { return 694 }
@@ -1764,8 +1753,8 @@ public struct SLL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Somali Shilling (SOS).
-public struct SOS: _CurrencyImplementation {
+/// The Somali Shilling (SOS) currency, as defined by ISO 4217.
+public struct SOS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Somali Shilling" }
   public static var alphabeticCode: String { return "SOS" }
   public static var numericCode: UInt16 { return 706 }
@@ -1778,8 +1767,8 @@ public struct SOS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Surinam Dollar (SRD).
-public struct SRD: _CurrencyImplementation {
+/// The Surinam Dollar (SRD) currency, as defined by ISO 4217.
+public struct SRD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Surinam Dollar" }
   public static var alphabeticCode: String { return "SRD" }
   public static var numericCode: UInt16 { return 968 }
@@ -1792,8 +1781,8 @@ public struct SRD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The South Sudanese Pound (SSP).
-public struct SSP: _CurrencyImplementation {
+/// The South Sudanese Pound (SSP) currency, as defined by ISO 4217.
+public struct SSP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "South Sudanese Pound" }
   public static var alphabeticCode: String { return "SSP" }
   public static var numericCode: UInt16 { return 728 }
@@ -1806,8 +1795,8 @@ public struct SSP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Dobra (STN).
-public struct STN: _CurrencyImplementation {
+/// The Dobra (STN) currency, as defined by ISO 4217.
+public struct STN: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Dobra" }
   public static var alphabeticCode: String { return "STN" }
   public static var numericCode: UInt16 { return 930 }
@@ -1820,8 +1809,8 @@ public struct STN: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The El Salvador Colon (SVC).
-public struct SVC: _CurrencyImplementation {
+/// The El Salvador Colon (SVC) currency, as defined by ISO 4217.
+public struct SVC: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "El Salvador Colon" }
   public static var alphabeticCode: String { return "SVC" }
   public static var numericCode: UInt16 { return 222 }
@@ -1834,8 +1823,8 @@ public struct SVC: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Syrian Pound (SYP).
-public struct SYP: _CurrencyImplementation {
+/// The Syrian Pound (SYP) currency, as defined by ISO 4217.
+public struct SYP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Syrian Pound" }
   public static var alphabeticCode: String { return "SYP" }
   public static var numericCode: UInt16 { return 760 }
@@ -1848,8 +1837,8 @@ public struct SYP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Lilangeni (SZL).
-public struct SZL: _CurrencyImplementation {
+/// The Lilangeni (SZL) currency, as defined by ISO 4217.
+public struct SZL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Lilangeni" }
   public static var alphabeticCode: String { return "SZL" }
   public static var numericCode: UInt16 { return 748 }
@@ -1862,8 +1851,8 @@ public struct SZL: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Baht (THB).
-public struct THB: _CurrencyImplementation {
+/// The Baht (THB) currency, as defined by ISO 4217.
+public struct THB: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Baht" }
   public static var alphabeticCode: String { return "THB" }
   public static var numericCode: UInt16 { return 764 }
@@ -1876,8 +1865,8 @@ public struct THB: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Somoni (TJS).
-public struct TJS: _CurrencyImplementation {
+/// The Somoni (TJS) currency, as defined by ISO 4217.
+public struct TJS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Somoni" }
   public static var alphabeticCode: String { return "TJS" }
   public static var numericCode: UInt16 { return 972 }
@@ -1890,8 +1879,8 @@ public struct TJS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Turkmenistan New Manat (TMT).
-public struct TMT: _CurrencyImplementation {
+/// The Turkmenistan New Manat (TMT) currency, as defined by ISO 4217.
+public struct TMT: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Turkmenistan New Manat" }
   public static var alphabeticCode: String { return "TMT" }
   public static var numericCode: UInt16 { return 934 }
@@ -1904,8 +1893,8 @@ public struct TMT: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Tunisian Dinar (TND).
-public struct TND: _CurrencyImplementation {
+/// The Tunisian Dinar (TND) currency, as defined by ISO 4217.
+public struct TND: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Tunisian Dinar" }
   public static var alphabeticCode: String { return "TND" }
   public static var numericCode: UInt16 { return 788 }
@@ -1918,8 +1907,8 @@ public struct TND: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Pa’anga (TOP).
-public struct TOP: _CurrencyImplementation {
+/// The Pa’anga (TOP) currency, as defined by ISO 4217.
+public struct TOP: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Pa’anga" }
   public static var alphabeticCode: String { return "TOP" }
   public static var numericCode: UInt16 { return 776 }
@@ -1932,8 +1921,8 @@ public struct TOP: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Turkish Lira (TRY).
-public struct TRY: _CurrencyImplementation {
+/// The Turkish Lira (TRY) currency, as defined by ISO 4217.
+public struct TRY: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Turkish Lira" }
   public static var alphabeticCode: String { return "TRY" }
   public static var numericCode: UInt16 { return 949 }
@@ -1946,8 +1935,8 @@ public struct TRY: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Trinidad and Tobago Dollar (TTD).
-public struct TTD: _CurrencyImplementation {
+/// The Trinidad and Tobago Dollar (TTD) currency, as defined by ISO 4217.
+public struct TTD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Trinidad and Tobago Dollar" }
   public static var alphabeticCode: String { return "TTD" }
   public static var numericCode: UInt16 { return 780 }
@@ -1960,8 +1949,8 @@ public struct TTD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The New Taiwan Dollar (TWD).
-public struct TWD: _CurrencyImplementation {
+/// The New Taiwan Dollar (TWD) currency, as defined by ISO 4217.
+public struct TWD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "New Taiwan Dollar" }
   public static var alphabeticCode: String { return "TWD" }
   public static var numericCode: UInt16 { return 901 }
@@ -1974,8 +1963,8 @@ public struct TWD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Tanzanian Shilling (TZS).
-public struct TZS: _CurrencyImplementation {
+/// The Tanzanian Shilling (TZS) currency, as defined by ISO 4217.
+public struct TZS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Tanzanian Shilling" }
   public static var alphabeticCode: String { return "TZS" }
   public static var numericCode: UInt16 { return 834 }
@@ -1988,8 +1977,8 @@ public struct TZS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Hryvnia (UAH).
-public struct UAH: _CurrencyImplementation {
+/// The Hryvnia (UAH) currency, as defined by ISO 4217.
+public struct UAH: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Hryvnia" }
   public static var alphabeticCode: String { return "UAH" }
   public static var numericCode: UInt16 { return 980 }
@@ -2002,8 +1991,8 @@ public struct UAH: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Uganda Shilling (UGX).
-public struct UGX: _CurrencyImplementation {
+/// The Uganda Shilling (UGX) currency, as defined by ISO 4217.
+public struct UGX: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Uganda Shilling" }
   public static var alphabeticCode: String { return "UGX" }
   public static var numericCode: UInt16 { return 800 }
@@ -2016,8 +2005,8 @@ public struct UGX: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The US Dollar (USD).
-public struct USD: _CurrencyImplementation {
+/// The US Dollar (USD) currency, as defined by ISO 4217.
+public struct USD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "US Dollar" }
   public static var alphabeticCode: String { return "USD" }
   public static var numericCode: UInt16 { return 840 }
@@ -2030,8 +2019,8 @@ public struct USD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Peso Uruguayo (UYU).
-public struct UYU: _CurrencyImplementation {
+/// The Peso Uruguayo (UYU) currency, as defined by ISO 4217.
+public struct UYU: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Peso Uruguayo" }
   public static var alphabeticCode: String { return "UYU" }
   public static var numericCode: UInt16 { return 858 }
@@ -2044,8 +2033,8 @@ public struct UYU: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Unidad Previsional (UYW).
-public struct UYW: _CurrencyImplementation {
+/// The Unidad Previsional (UYW) currency, as defined by ISO 4217.
+public struct UYW: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Unidad Previsional" }
   public static var alphabeticCode: String { return "UYW" }
   public static var numericCode: UInt16 { return 927 }
@@ -2058,8 +2047,8 @@ public struct UYW: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Uzbekistan Sum (UZS).
-public struct UZS: _CurrencyImplementation {
+/// The Uzbekistan Sum (UZS) currency, as defined by ISO 4217.
+public struct UZS: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Uzbekistan Sum" }
   public static var alphabeticCode: String { return "UZS" }
   public static var numericCode: UInt16 { return 860 }
@@ -2072,8 +2061,8 @@ public struct UZS: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Bolívar Soberano (VES).
-public struct VES: _CurrencyImplementation {
+/// The Bolívar Soberano (VES) currency, as defined by ISO 4217.
+public struct VES: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Bolívar Soberano" }
   public static var alphabeticCode: String { return "VES" }
   public static var numericCode: UInt16 { return 928 }
@@ -2086,8 +2075,8 @@ public struct VES: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Dong (VND).
-public struct VND: _CurrencyImplementation {
+/// The Dong (VND) currency, as defined by ISO 4217.
+public struct VND: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Dong" }
   public static var alphabeticCode: String { return "VND" }
   public static var numericCode: UInt16 { return 704 }
@@ -2100,8 +2089,8 @@ public struct VND: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Vatu (VUV).
-public struct VUV: _CurrencyImplementation {
+/// The Vatu (VUV) currency, as defined by ISO 4217.
+public struct VUV: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Vatu" }
   public static var alphabeticCode: String { return "VUV" }
   public static var numericCode: UInt16 { return 548 }
@@ -2114,8 +2103,8 @@ public struct VUV: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Tala (WST).
-public struct WST: _CurrencyImplementation {
+/// The Tala (WST) currency, as defined by ISO 4217.
+public struct WST: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Tala" }
   public static var alphabeticCode: String { return "WST" }
   public static var numericCode: UInt16 { return 882 }
@@ -2128,8 +2117,8 @@ public struct WST: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The CFA Franc BEAC (XAF).
-public struct XAF: _CurrencyImplementation {
+/// The CFA Franc BEAC (XAF) currency, as defined by ISO 4217.
+public struct XAF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "CFA Franc BEAC" }
   public static var alphabeticCode: String { return "XAF" }
   public static var numericCode: UInt16 { return 950 }
@@ -2142,8 +2131,8 @@ public struct XAF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The East Caribbean Dollar (XCD).
-public struct XCD: _CurrencyImplementation {
+/// The East Caribbean Dollar (XCD) currency, as defined by ISO 4217.
+public struct XCD: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "East Caribbean Dollar" }
   public static var alphabeticCode: String { return "XCD" }
   public static var numericCode: UInt16 { return 951 }
@@ -2156,8 +2145,8 @@ public struct XCD: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The CFA Franc BCEAO (XOF).
-public struct XOF: _CurrencyImplementation {
+/// The CFA Franc BCEAO (XOF) currency, as defined by ISO 4217.
+public struct XOF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "CFA Franc BCEAO" }
   public static var alphabeticCode: String { return "XOF" }
   public static var numericCode: UInt16 { return 952 }
@@ -2170,8 +2159,8 @@ public struct XOF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The CFP Franc (XPF).
-public struct XPF: _CurrencyImplementation {
+/// The CFP Franc (XPF) currency, as defined by ISO 4217.
+public struct XPF: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "CFP Franc" }
   public static var alphabeticCode: String { return "XPF" }
   public static var numericCode: UInt16 { return 953 }
@@ -2184,8 +2173,8 @@ public struct XPF: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Yemeni Rial (YER).
-public struct YER: _CurrencyImplementation {
+/// The Yemeni Rial (YER) currency, as defined by ISO 4217.
+public struct YER: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Yemeni Rial" }
   public static var alphabeticCode: String { return "YER" }
   public static var numericCode: UInt16 { return 886 }
@@ -2198,8 +2187,8 @@ public struct YER: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Rand (ZAR).
-public struct ZAR: _CurrencyImplementation {
+/// The Rand (ZAR) currency, as defined by ISO 4217.
+public struct ZAR: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Rand" }
   public static var alphabeticCode: String { return "ZAR" }
   public static var numericCode: UInt16 { return 710 }
@@ -2212,8 +2201,8 @@ public struct ZAR: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Zambian Kwacha (ZMW).
-public struct ZMW: _CurrencyImplementation {
+/// The Zambian Kwacha (ZMW) currency, as defined by ISO 4217.
+public struct ZMW: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Zambian Kwacha" }
   public static var alphabeticCode: String { return "ZMW" }
   public static var numericCode: UInt16 { return 967 }
@@ -2226,8 +2215,8 @@ public struct ZMW: _CurrencyImplementation {
   private let _minorUnits: Int64
 }
 
-/// The Zimbabwe Dollar (ZWL).
-public struct ZWL: _CurrencyImplementation {
+/// The Zimbabwe Dollar (ZWL) currency, as defined by ISO 4217.
+public struct ZWL: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "Zimbabwe Dollar" }
   public static var alphabeticCode: String { return "ZWL" }
   public static var numericCode: UInt16 { return 932 }

--- a/Sources/Currency/ISOCurrencies.swift.gyb
+++ b/Sources/Currency/ISOCurrencies.swift.gyb
@@ -12,17 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Decimal
-
-/// This is a "private" protocol for conforming all ISO 4217 defined currencies to a list of different protocols.
-/// - Warning: Do not conform any type to this protocol, nor use it as a type constraint.
-///
-/// Breaking changes to this **will** be allowed outside of major semver changes.
-public protocol _CurrencyImplementation: AnyCurrency, CurrencyMetadata,
-  Comparable, Hashable,
-  ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral,
-  AdditiveArithmetic { }
-
 % warning = "Contents following this line are automatically generated, and should not be edited."
 // ${warning}
 
@@ -39,8 +28,8 @@ public protocol _CurrencyImplementation: AnyCurrency, CurrencyMetadata,
     minorUnit = row["CcyMnrUnts"]
     }%
     % if alphaCode and numCode and numCode.isdigit() and name and minorUnit and minorUnit.isdigit():
-/// The ${name} (${alphaCode}).
-public struct ${alphaCode}: _CurrencyImplementation {
+/// The ${name} (${alphaCode}) currency, as defined by ISO 4217.
+public struct ${alphaCode}: CurrencyProtocol, CurrencyMetadata {
   public static var name: String { return "${name}" }
   public static var alphabeticCode: String { return "${alphaCode}" }
   public static var numericCode: UInt16 { return ${numCode} }

--- a/swift-currency.xcodeproj/project.pbxproj
+++ b/swift-currency.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		D814C41723D68385007D4037 /* CurrencyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814C41623D68385007D4037 /* CurrencyProtocol.swift */; };
 		D838378B23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838378A23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift */; };
 		D893657D23D2944B0006FAE1 /* AnyCurrencyAlgorithmsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893657C23D2944B0006FAE1 /* AnyCurrencyAlgorithmsTests.swift */; };
 		D893657F23D294850006FAE1 /* AnyCurrency+Algorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893657E23D294850006FAE1 /* AnyCurrency+Algorithms.swift */; };
@@ -53,6 +54,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D814C41623D68385007D4037 /* CurrencyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyProtocol.swift; sourceTree = "<group>"; };
 		D838378A23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnyCurrency+Sequence.swift"; sourceTree = "<group>"; };
 		D893657C23D2944B0006FAE1 /* AnyCurrencyAlgorithmsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCurrencyAlgorithmsTests.swift; sourceTree = "<group>"; };
 		D893657E23D294850006FAE1 /* AnyCurrency+Algorithms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyCurrency+Algorithms.swift"; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 				OBJ_13 /* CurrencyMint.swift */,
 				OBJ_14 /* ISOCurrencies.swift */,
 				D893657E23D294850006FAE1 /* AnyCurrency+Algorithms.swift */,
+				D814C41623D68385007D4037 /* CurrencyProtocol.swift */,
 			);
 			name = Currency;
 			path = Sources/Currency;
@@ -242,6 +245,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				D814C41723D68385007D4037 /* CurrencyProtocol.swift in Sources */,
 				OBJ_31 /* AnyCurrency.swift in Sources */,
 				OBJ_32 /* CurrencyMetadata.swift in Sources */,
 				D838378B23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift in Sources */,


### PR DESCRIPTION
Motivation:

Working with currencies in generic cases aren't always practical with the type-erased `AnyCurrency` protocol, as repeated type constraints are added to access `Comparable` and `Hashable` conformances.

The `_CurrencyImplementation` doesn't need to be private, as anyone could conform to the protocol to gain much of the flexibility of `AnyCurrency` while also working in hashing contexts such as `Set`.

Modifications:

- Rename `_CurrencyImplementation` to `CurrencyProtocol` and make public
- Remove `CurrencyMetadata` superset requirements from `CurrencyProtocol`

Result:

Developers should have more flexibility with the Currency module types to work in existential or generic contexts