### PR TITLE
Rework AnyCurrency and CurrencyProtocol implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let gbp = GBP(109.23)
 print(usd + gbp) // compile error
 
 let jpy: JPY = 399 // JPY(399)
-print("The total cost is \(JPY, forLocale: .init(identifier: "fr_FR")).)
+print("The total cost is \(localize: JPY, forLocale: .init(identifier: "fr_FR")).)
 // "The total cost is 399 JPY."
 ```
 

--- a/Sources/Currency/AnyCurrency+Sequence.swift
+++ b/Sources/Currency/AnyCurrency+Sequence.swift
@@ -29,11 +29,10 @@ extension Sequence where Element: AnyCurrency {
   /// If the sequence has no elements, you will receive a currency with a value of "0".
   /// - Complexity: O(*n*) , where *n* is the length of the sequence.
   /// - Returns: A currency value representing the sum total of all the amounts in the sequence.
-  @inlinable
   public func sum() -> Element {
-    return self.reduce(into: .init(.zero), { $0 += $1 })
+    return self.reduce(into: .zero, +=)
   }
-  
+
   /// Returns the sum total of all amounts in the sequence that satify the given predicate.
   /// For example:
   ///
@@ -48,12 +47,12 @@ extension Sequence where Element: AnyCurrency {
   /// - Returns: A currency value representing the sum total of all the amounts `isIncluded` allowed.
   @inlinable
   public func sum(where isIncluded: (Element) throws -> Bool) rethrows -> Element {
-    return try self.reduce(into: Element(0)) { result, next in
+    return try self.reduce(into: .zero) { result, next in
       guard try isIncluded(next) else { return }
       result += next
     }
   }
-  
+
   /// Returns the sum total of amounts in the sequence after applying the provided transform.
   ///
   /// Rather than doing a `.map(_:)` and then `.sum()`, the `sum` result will be calculated inline while applying the transformations.
@@ -71,6 +70,6 @@ extension Sequence where Element: AnyCurrency {
   /// - Returns: A currency value representing the sum total of all the transformed amounts in the sequence.
   @inlinable
   public func sum(_ transform: (Element) throws -> (Element)) rethrows -> Element {
-    return try self.reduce(into: .init(.zero)) { $0 += try transform($1) }
+    return try self.reduce(into: .zero) { $0 += try transform($1) }
   }
 }

--- a/Sources/Currency/AnyCurrency.swift
+++ b/Sources/Currency/AnyCurrency.swift
@@ -199,10 +199,17 @@ extension String.StringInterpolation {
   ) {
     guard case let .some(value) = value else { return nilValue.write(to: &self) }
 
+    #if swift(<5.1)
+    guard let localizedString = formatter.string(from: NSDecimalNumber(decimal: value.amount)) else {
+      nilValue.write(to: &self)
+      return
+    }
+    #else
     guard let localizedString = formatter.string(from: value.amount as NSDecimalNumber) else {
       nilValue.write(to: &self)
       return
     }
+    #endif
 
     localizedString.write(to: &self)
   }

--- a/Sources/Currency/CurrencyMint.swift
+++ b/Sources/Currency/CurrencyMint.swift
@@ -32,7 +32,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(alphabeticCode code: String, amount: Decimal) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byAlphaCode: code) else { return nil }
-    return currencyType.init(amount)
+    return currencyType.init(amount: amount)
   }
   
   /// Attempts to find the appropriate currency type that matches the provided alphabetic code and initialize it.
@@ -44,7 +44,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(alphabeticCode code: String, minorUnits: Int64) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byAlphaCode: code) else { return nil }
-    return currencyType.init(exactly: minorUnits)
+    return currencyType.init(minorUnits: minorUnits)
   }
   
   /// Attempts to find the appropriate currency type that matches the provided numeric code and initialize it.
@@ -61,7 +61,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(numericCode code: UInt16, amount: Decimal) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byNumCode: code) else { return nil }
-    return currencyType.init(amount)
+    return currencyType.init(amount: amount)
   }
   
   /// Attempts to find the appropriate currency type that matches the provided numeric code and initialize it.
@@ -73,7 +73,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(numericCode code: UInt16, minorUnits: Int64) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byNumCode: code) else { return nil }
-    return currencyType.init(exactly: minorUnits)
+    return currencyType.init(minorUnits: minorUnits)
   }
 }
 

--- a/Sources/Currency/CurrencyMint.swift.gyb
+++ b/Sources/Currency/CurrencyMint.swift.gyb
@@ -32,7 +32,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(alphabeticCode code: String, amount: Decimal) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byAlphaCode: code) else { return nil }
-    return currencyType.init(amount)
+    return currencyType.init(amount: amount)
   }
   
   /// Attempts to find the appropriate currency type that matches the provided alphabetic code and initialize it.
@@ -44,7 +44,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(alphabeticCode code: String, minorUnits: Int64) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byAlphaCode: code) else { return nil }
-    return currencyType.init(exactly: minorUnits)
+    return currencyType.init(minorUnits: minorUnits)
   }
   
   /// Attempts to find the appropriate currency type that matches the provided numeric code and initialize it.
@@ -61,7 +61,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(numericCode code: UInt16, amount: Decimal) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byNumCode: code) else { return nil }
-    return currencyType.init(amount)
+    return currencyType.init(amount: amount)
   }
   
   /// Attempts to find the appropriate currency type that matches the provided numeric code and initialize it.
@@ -73,7 +73,7 @@ public final class CurrencyMint {
   /// - Returns: An instance of a currency that matches the provided `code`, with the appropriate value. Otherwise `nil`.
   public func make(numericCode code: UInt16, minorUnits: Int64) -> AnyCurrency? {
     guard let currencyType = CurrencyMint.lookup(byNumCode: code) else { return nil }
-    return currencyType.init(exactly: minorUnits)
+    return currencyType.init(minorUnits: minorUnits)
   }
 }
 

--- a/Sources/Currency/CurrencyProtocol.swift
+++ b/Sources/Currency/CurrencyProtocol.swift
@@ -12,14 +12,40 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Represents a type that acts as a currency.
+import struct Foundation.Decimal
+
+/// A representation of a value in a specific currency.
 ///
-/// Any `CurrencyProtocol` type behaves exactly like an `AnyCurrency` type, while also providing other capabilities such as
-/// `Comparable`, `Hashable`, etc.
+/// When a value instance needs to be used outside of a generic context, the `AnyCurrency` protocol can be used as an existential.
 ///
-/// This is the type to work with in most generic cases, as `AnyCurrency` is a type-erasure protocol when existentials are needed.
+/// `CurrencyProtocol` provides the same functionality of `AnyCurrency`,
+/// in addition to `Comparable`, `Hashable`, `ExpressibleByIntegerLiteral` and `ExpressibleByFloatLiteral`.
 public protocol CurrencyProtocol: AnyCurrency,
   Comparable, Hashable,
-  ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral,
-  AdditiveArithmetic
+  AdditiveArithmetic,
+  ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral
 { }
+
+// MARK: Default Implementations
+
+extension CurrencyProtocol {
+  public init(floatLiteral value: Double) {
+    self.init(scalingAndRounding: Decimal(value))
+  }
+
+  public init(integerLiteral value: Int64) {
+    self.init(scalingAndRounding: Decimal(value))
+  }
+}
+
+// MARK: AnyCurrency Implementation Overrides
+
+extension CurrencyProtocol {
+  public static var zero: Self { return Self(minorUnits: 0) }
+
+  // https://bugs.swift.org/browse/SR-12128
+  #if swift(>=5.2)
+  public static func +=(lhs: inout Self, rhs: Self) { lhs = lhs + rhs }
+  public static func -=(lhs: inout Self, rhs: Self) { lhs = lhs - rhs }
+  #endif
+}

--- a/Sources/Currency/Extensions/Decimal.swift
+++ b/Sources/Currency/Extensions/Decimal.swift
@@ -15,7 +15,11 @@
 import Foundation
 
 extension Decimal {
+  #if swift(<5.1)
+  internal var int64Value: Int64 { return NSDecimalNumber(decimal: self).int64Value }
+  #else
   internal var int64Value: Int64 { return (self as NSNumber).int64Value }
+  #endif
 
   internal func roundedAndScaled(to unitScale: UInt8) -> Decimal {
     let scale = Int(unitScale)

--- a/Sources/Currency/Extensions/Decimal.swift
+++ b/Sources/Currency/Extensions/Decimal.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2020 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension Decimal {
+  internal var int64Value: Int64 { return (self as NSNumber).int64Value }
+
+  internal func roundedAndScaled(to unitScale: UInt8) -> Decimal {
+    let scale = Int(unitScale)
+    var result = Decimal.zero
+    withUnsafePointer(to: self) { NSDecimalRound(&result, $0, scale, .bankers) }
+    return result.scaled(to: scale)
+  }
+  
+  internal func scaled(to scale: Int, inverse: Bool = false) -> Decimal {
+    return self * .init(
+      sign: .plus,
+      exponent: inverse ? scale * -1 : scale,
+      significand: 1
+    )
+  }
+}

--- a/Sources/Currency/ISOCurrencies.swift
+++ b/Sources/Currency/ISOCurrencies.swift
@@ -26,7 +26,7 @@ public struct AED: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -40,7 +40,7 @@ public struct AFN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -54,7 +54,7 @@ public struct ALL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -68,7 +68,7 @@ public struct AMD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -82,7 +82,7 @@ public struct ANG: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -96,7 +96,7 @@ public struct AOA: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -110,7 +110,7 @@ public struct ARS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -124,7 +124,7 @@ public struct AUD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -138,7 +138,7 @@ public struct AWG: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -152,7 +152,7 @@ public struct AZN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -166,7 +166,7 @@ public struct BAM: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -180,7 +180,7 @@ public struct BBD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -194,7 +194,7 @@ public struct BDT: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -208,7 +208,7 @@ public struct BGN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -222,7 +222,7 @@ public struct BHD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -236,7 +236,7 @@ public struct BIF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -250,7 +250,7 @@ public struct BMD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -264,7 +264,7 @@ public struct BND: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -278,7 +278,7 @@ public struct BOB: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -292,7 +292,7 @@ public struct BRL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -306,7 +306,7 @@ public struct BSD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -320,7 +320,7 @@ public struct BTN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -334,7 +334,7 @@ public struct BWP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -348,7 +348,7 @@ public struct BYN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -362,7 +362,7 @@ public struct BZD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -376,7 +376,7 @@ public struct CAD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -390,7 +390,7 @@ public struct CDF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -404,7 +404,7 @@ public struct CHF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -418,7 +418,7 @@ public struct CLP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -432,7 +432,7 @@ public struct CNY: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -446,7 +446,7 @@ public struct COP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -460,7 +460,7 @@ public struct CRC: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -474,7 +474,7 @@ public struct CUC: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -488,7 +488,7 @@ public struct CUP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -502,7 +502,7 @@ public struct CVE: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -516,7 +516,7 @@ public struct CZK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -530,7 +530,7 @@ public struct DJF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -544,7 +544,7 @@ public struct DKK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -558,7 +558,7 @@ public struct DOP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -572,7 +572,7 @@ public struct DZD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -586,7 +586,7 @@ public struct EGP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -600,7 +600,7 @@ public struct ERN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -614,7 +614,7 @@ public struct ETB: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -628,7 +628,7 @@ public struct EUR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -642,7 +642,7 @@ public struct FJD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -656,7 +656,7 @@ public struct FKP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -670,7 +670,7 @@ public struct GBP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -684,7 +684,7 @@ public struct GEL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -698,7 +698,7 @@ public struct GHS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -712,7 +712,7 @@ public struct GIP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -726,7 +726,7 @@ public struct GMD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -740,7 +740,7 @@ public struct GNF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -754,7 +754,7 @@ public struct GTQ: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -768,7 +768,7 @@ public struct GYD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -782,7 +782,7 @@ public struct HKD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -796,7 +796,7 @@ public struct HNL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -810,7 +810,7 @@ public struct HRK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -824,7 +824,7 @@ public struct HTG: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -838,7 +838,7 @@ public struct HUF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -852,7 +852,7 @@ public struct IDR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -866,7 +866,7 @@ public struct ILS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -880,7 +880,7 @@ public struct INR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -894,7 +894,7 @@ public struct IQD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -908,7 +908,7 @@ public struct IRR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -922,7 +922,7 @@ public struct ISK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -936,7 +936,7 @@ public struct JMD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -950,7 +950,7 @@ public struct JOD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -964,7 +964,7 @@ public struct JPY: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -978,7 +978,7 @@ public struct KES: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -992,7 +992,7 @@ public struct KGS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1006,7 +1006,7 @@ public struct KHR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1020,7 +1020,7 @@ public struct KMF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1034,7 +1034,7 @@ public struct KPW: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1048,7 +1048,7 @@ public struct KRW: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1062,7 +1062,7 @@ public struct KWD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1076,7 +1076,7 @@ public struct KYD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1090,7 +1090,7 @@ public struct KZT: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1104,7 +1104,7 @@ public struct LAK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1118,7 +1118,7 @@ public struct LBP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1132,7 +1132,7 @@ public struct LKR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1146,7 +1146,7 @@ public struct LRD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1160,7 +1160,7 @@ public struct LSL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1174,7 +1174,7 @@ public struct LYD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1188,7 +1188,7 @@ public struct MAD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1202,7 +1202,7 @@ public struct MDL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1216,7 +1216,7 @@ public struct MGA: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1230,7 +1230,7 @@ public struct MKD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1244,7 +1244,7 @@ public struct MMK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1258,7 +1258,7 @@ public struct MNT: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1272,7 +1272,7 @@ public struct MOP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1286,7 +1286,7 @@ public struct MRU: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1300,7 +1300,7 @@ public struct MUR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1314,7 +1314,7 @@ public struct MVR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1328,7 +1328,7 @@ public struct MWK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1342,7 +1342,7 @@ public struct MXN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1356,7 +1356,7 @@ public struct MYR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1370,7 +1370,7 @@ public struct MZN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1384,7 +1384,7 @@ public struct NAD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1398,7 +1398,7 @@ public struct NGN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1412,7 +1412,7 @@ public struct NIO: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1426,7 +1426,7 @@ public struct NOK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1440,7 +1440,7 @@ public struct NPR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1454,7 +1454,7 @@ public struct NZD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1468,7 +1468,7 @@ public struct OMR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1482,7 +1482,7 @@ public struct PAB: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1496,7 +1496,7 @@ public struct PEN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1510,7 +1510,7 @@ public struct PGK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1524,7 +1524,7 @@ public struct PHP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1538,7 +1538,7 @@ public struct PKR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1552,7 +1552,7 @@ public struct PLN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1566,7 +1566,7 @@ public struct PYG: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1580,7 +1580,7 @@ public struct QAR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1594,7 +1594,7 @@ public struct RON: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1608,7 +1608,7 @@ public struct RSD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1622,7 +1622,7 @@ public struct RUB: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1636,7 +1636,7 @@ public struct RWF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1650,7 +1650,7 @@ public struct SAR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1664,7 +1664,7 @@ public struct SBD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1678,7 +1678,7 @@ public struct SCR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1692,7 +1692,7 @@ public struct SDG: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1706,7 +1706,7 @@ public struct SEK: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1720,7 +1720,7 @@ public struct SGD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1734,7 +1734,7 @@ public struct SHP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1748,7 +1748,7 @@ public struct SLL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1762,7 +1762,7 @@ public struct SOS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1776,7 +1776,7 @@ public struct SRD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1790,7 +1790,7 @@ public struct SSP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1804,7 +1804,7 @@ public struct STN: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1818,7 +1818,7 @@ public struct SVC: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1832,7 +1832,7 @@ public struct SYP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1846,7 +1846,7 @@ public struct SZL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1860,7 +1860,7 @@ public struct THB: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1874,7 +1874,7 @@ public struct TJS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1888,7 +1888,7 @@ public struct TMT: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1902,7 +1902,7 @@ public struct TND: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1916,7 +1916,7 @@ public struct TOP: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1930,7 +1930,7 @@ public struct TRY: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1944,7 +1944,7 @@ public struct TTD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1958,7 +1958,7 @@ public struct TWD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1972,7 +1972,7 @@ public struct TZS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -1986,7 +1986,7 @@ public struct UAH: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2000,7 +2000,7 @@ public struct UGX: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2014,7 +2014,7 @@ public struct USD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2028,7 +2028,7 @@ public struct UYU: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2042,7 +2042,7 @@ public struct UYW: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2056,7 +2056,7 @@ public struct UZS: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2070,7 +2070,7 @@ public struct VES: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2084,7 +2084,7 @@ public struct VND: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2098,7 +2098,7 @@ public struct VUV: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2112,7 +2112,7 @@ public struct WST: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2126,7 +2126,7 @@ public struct XAF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2140,7 +2140,7 @@ public struct XCD: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2154,7 +2154,7 @@ public struct XOF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2168,7 +2168,7 @@ public struct XPF: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2182,7 +2182,7 @@ public struct YER: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2196,7 +2196,7 @@ public struct ZAR: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2210,7 +2210,7 @@ public struct ZMW: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2224,7 +2224,7 @@ public struct ZWL: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }
@@ -2238,7 +2238,7 @@ public struct XXX: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }

--- a/Sources/Currency/ISOCurrencies.swift.gyb
+++ b/Sources/Currency/ISOCurrencies.swift.gyb
@@ -41,7 +41,7 @@ public struct ${alphaCode}: CurrencyProtocol, CurrencyMetadata {
   
   public var minorUnits: Int64 { return self._minorUnits }
   
-  public init(exactly minorUnits: Int64) { self._minorUnits = minorUnits }
+  public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
   
   private let _minorUnits: Int64
 }

--- a/Tests/CurrencyTests/AnyCurrencyAlgorithmsTests.swift
+++ b/Tests/CurrencyTests/AnyCurrencyAlgorithmsTests.swift
@@ -17,6 +17,22 @@ import XCTest
 
 public final class AnyCurrencyAlgorithmsTests: XCTestCase { }
 
+// MARK: Sequence<AnyCurrency>
+
+extension AnyCurrencyAlgorithmsTests {
+  func testSequenceSum() {
+    let amounts = [USD(30.47), -107.8239, 1_203.9832, -504.3982]
+    XCTAssertEqual(amounts.sum().amount, 622.23)
+  }
+  
+  func testSequenceSum_withPredicate() {
+    let amounts: [USD] = [304.98, 19.02, 30.21]
+    let sumTotal = amounts.sum(where: { $0.amount > 20 })
+    XCTAssertEqual(sumTotal.amount, 335.19)
+  }
+}
+
+
 // MARK: Distributed Evenly
 
 extension AnyCurrencyAlgorithmsTests {
@@ -25,7 +41,7 @@ extension AnyCurrencyAlgorithmsTests {
     XCTAssertEqual(amount.distributedEvenly(intoParts: 3), [5.01, 5, 5])
     XCTAssertEqual(amount.distributedEvenly(intoParts: 0), [])
     XCTAssertEqual(amount.distributedEvenly(intoParts: -1), [])
-    XCTAssertEqual(amount.inverseAmount.distributedEvenly(intoParts: 4), [-3.76, -3.75, -3.75, -3.75])
+    XCTAssertEqual(amount.negated().distributedEvenly(intoParts: 4), [-3.76, -3.75, -3.75, -3.75])
   }
 
   // minorUnits == 2
@@ -82,8 +98,8 @@ extension AnyCurrencyAlgorithmsTests {
     XCTAssertEqual(actualResults, expectedResults, file: file, line: line)
     XCTAssertEqual(sourceAmount, expectedResults.sum(), file: file, line: line)
     XCTAssertEqual(
-      sourceAmount.inverseAmount.distributedEvenly(intoParts: count),
-      expectedResults.map({ $0.inverseAmount }),
+      sourceAmount.negated().distributedEvenly(intoParts: count),
+      expectedResults.map({ $0.negated() }),
       file: file, line: line
     )
   }
@@ -96,7 +112,7 @@ extension AnyCurrencyAlgorithmsTests {
     let amount = USD(10)
     XCTAssertEqual(amount.distributedProportionally(between: [2.5, 2.5]), [5, 5])
     XCTAssertEqual(amount.distributedProportionally(between: []), [])
-    XCTAssertEqual(amount.inverseAmount.distributedProportionally(between: [5, 8.25]), [-3.77, -6.23])
+    XCTAssertEqual(amount.negated().distributedProportionally(between: [5, 8.25]), [-3.77, -6.23])
   }
   
   // minorUnits == 2
@@ -151,12 +167,13 @@ extension AnyCurrencyAlgorithmsTests {
   }
   
   private func run_distributedProportionallyTest<Currency: AnyCurrency & Equatable>(
-    sourceAmount: Currency,
+    sourceAmount: Currency?,
     originalValues: [Currency],
     expectedValues: [Currency],
     file: StaticString = #file,
     line: UInt = #line
   ) {
+    guard let sourceAmount = sourceAmount else { return XCTFail("sourceAmount is nil!", file: file, line: line) }
     guard originalValues.count == expectedValues.count else {
       return XCTFail(
         "Inconsistent desire: Provided \(originalValues.count) values, but expect \(expectedValues.count) results",

--- a/Tests/CurrencyTests/AnyCurrencyTests.swift
+++ b/Tests/CurrencyTests/AnyCurrencyTests.swift
@@ -146,7 +146,7 @@ extension AnyCurrencyTests {
     XCTAssertEqual("\(localize: yen, forLocale: .init(identifier: "el"))", expectedGreekYen)
 
     let dinar = KWD(100.9289)
-    #if swift(<5.2)
+    #if swift(<5.2) && os(Linux)
     let expectedIrishDinar = "KWD100.929"
     #else
     let expectedIrishDinar = "KWD 100.929"

--- a/Tests/CurrencyTests/AnyCurrencyTests.swift
+++ b/Tests/CurrencyTests/AnyCurrencyTests.swift
@@ -121,7 +121,7 @@ extension AnyCurrencyTests {
     #endif
     XCTAssertEqual("\(localize: KWD(301.9823))", expectedDinar)
 
-    #if swift(<5.1)
+    #if swift(<5.1) && os(Linux)
     let expectedYen = "¥401.00"
     #else
     let expectedYen = "¥401"

--- a/Tests/CurrencyTests/AnyCurrencyTests.swift
+++ b/Tests/CurrencyTests/AnyCurrencyTests.swift
@@ -30,21 +30,21 @@ final class AnyCurrencyTests: XCTestCase {
   }
   
   func testMinorUnits() {
-    let gbp = GBP(exactly: 300)
+    let gbp = GBP(minorUnits: 300)
     XCTAssertTrue(gbp.isEqual(to: 3.0))
     XCTAssertEqual(gbp.minorUnits, 300)
     
-    let jpy = JPY(exactly: 39820)
+    let jpy = JPY(minorUnits: 39820)
     XCTAssertTrue(jpy.isEqual(to: 39820))
     XCTAssertEqual(jpy.minorUnits, 39820)
   }
   
   func testNegative() {
-    let gbp = GBP(exactly: -300)
+    let gbp = GBP(minorUnits: -300)
     XCTAssertTrue(gbp.isEqual(to: -3.0))
     XCTAssertEqual(gbp.minorUnits, -300)
     
-    let jpy = JPY(exactly: -39820)
+    let jpy = JPY(minorUnits: -39820)
     XCTAssertTrue(jpy.isEqual(to: -39820))
     XCTAssertEqual(jpy.minorUnits, -39820)
   }

--- a/Tests/CurrencyTests/AnyCurrencyTests.swift
+++ b/Tests/CurrencyTests/AnyCurrencyTests.swift
@@ -113,23 +113,70 @@ extension AnyCurrencyTests {
 
   func testStringInterpolation_defaultFormatter() {
     XCTAssertEqual("\(localize: USD(4321.389))", "$4,321.39")
-    XCTAssertEqual("\(localize: JPY(400.9))", "¥401")
+
+    #if swift(<5.2) && os(Linux)
+    let expectedDinar = "KWD301.982"
+    #else
+    let expectedDinar = "KWD 301.982"
+    #endif
+    XCTAssertEqual("\(localize: KWD(301.9823))", expectedDinar)
+
+    #if swift(<5.1)
+    let expectedYen = "¥401.00"
+    #else
+    let expectedYen = "¥401"
+    #endif
+    XCTAssertEqual("\(localize: JPY(400.9))", expectedYen)
   }
 
   func testStringInterpolation_customLocale() {
     let pounds = GBP(14928.789)
     XCTAssertEqual("\(localize: pounds, forLocale: .init(identifier: "en_UK"))", "£14,928.79")
     XCTAssertEqual("\(localize: pounds, forLocale: .init(identifier: "de_DE"))", "14.928,79 £")
+
+    let yen = JPY(400.9)
+    #if swift(<5.1) && os(Linux)
+    let expectedFrenchYen = "401,00 JPY"
+    let expectedGreekYen = "401,00 JP¥"
+    #else
+    let expectedFrenchYen = "401 JPY"
+    let expectedGreekYen = "401 JP¥"
+    #endif
+    XCTAssertEqual("\(localize: yen, forLocale: .init(identifier: "fr"))", expectedFrenchYen)
+    XCTAssertEqual("\(localize: yen, forLocale: .init(identifier: "el"))", expectedGreekYen)
+
+    let dinar = KWD(100.9289)
+    #if swift(<5.2)
+    let expectedIrishDinar = "KWD100.929"
+    #else
+    let expectedIrishDinar = "KWD 100.929"
+    #endif
+    XCTAssertEqual("\(localize: dinar, forLocale: .init(identifier: "ga"))", expectedIrishDinar)
+    XCTAssertEqual("\(localize: dinar, forLocale: .init(identifier: "hr"))", "100,929 KWD")
   }
 
   func testStringInterpolation_customFormatter() {
-    let pounds = GBP(14928.018)
     let formatter = NumberFormatter()
-    formatter.currencyCode = GBP.metadata.alphabeticCode
     formatter.numberStyle = .currency
     formatter.currencyGroupingSeparator = " "
     formatter.currencyDecimalSeparator = "'"
+
+    let pounds = GBP(14928.018)
+    formatter.currencyCode = GBP.alphabeticCode
     XCTAssertEqual("\(localize: pounds, withFormatter: formatter)", "£14 928'02")
+
+    let yen = JPY(4000.9)
+    formatter.currencyCode = JPY.alphabeticCode
+    XCTAssertEqual("\(localize: yen, withFormatter: formatter)", "¥4 001")
+
+    let dinar = KWD(92.0299)
+    formatter.currencyCode = KWD.alphabeticCode
+    #if swift(<5.2) && os(Linux)
+    let expectedDinar = "KWD92'030"
+    #else
+    let expectedDinar = "KWD 92'030"
+    #endif
+    XCTAssertEqual("\(localize: dinar, withFormatter: formatter)", expectedDinar)
   }
 
   func testStringInterpolation_optional() {

--- a/swift-currency.xcodeproj/project.pbxproj
+++ b/swift-currency.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		03AE0FB82401E5BA00A76C38 /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AE0FB72401E5BA00A76C38 /* Decimal.swift */; };
 		D814C41723D68385007D4037 /* CurrencyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814C41623D68385007D4037 /* CurrencyProtocol.swift */; };
 		D838378B23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838378A23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift */; };
 		D893657D23D2944B0006FAE1 /* AnyCurrencyAlgorithmsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893657C23D2944B0006FAE1 /* AnyCurrencyAlgorithmsTests.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03AE0FB72401E5BA00A76C38 /* Decimal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decimal.swift; sourceTree = "<group>"; };
 		D814C41623D68385007D4037 /* CurrencyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyProtocol.swift; sourceTree = "<group>"; };
 		D838378A23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnyCurrency+Sequence.swift"; sourceTree = "<group>"; };
 		D893657C23D2944B0006FAE1 /* AnyCurrencyAlgorithmsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCurrencyAlgorithmsTests.swift; sourceTree = "<group>"; };
@@ -94,6 +96,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		03AE0FB62401E5B000A76C38 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				03AE0FB72401E5BA00A76C38 /* Decimal.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		OBJ_15 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -149,6 +159,7 @@
 		OBJ_8 /* Currency */ = {
 			isa = PBXGroup;
 			children = (
+				03AE0FB62401E5B000A76C38 /* Extensions */,
 				OBJ_11 /* AnyCurrency.swift */,
 				D893657E23D294850006FAE1 /* AnyCurrency+Algorithms.swift */,
 				D838378A23CEBF2D0017B4D2 /* AnyCurrency+Sequence.swift */,
@@ -276,6 +287,7 @@
 				D893657F23D294850006FAE1 /* AnyCurrency+Algorithms.swift in Sources */,
 				OBJ_33 /* CurrencyMint.swift in Sources */,
 				OBJ_34 /* ISOCurrencies.swift in Sources */,
+				03AE0FB82401E5BA00A76C38 /* Decimal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Motivation:

While working on linux CI (#7) and due to bug #17, many holes in the current implementation were found.

These include issues with handling NaN representations, integer overflow, performance, and code reusability.

The primary issue is that the default implementations for protocol requirements
were not playing nicely with each other, especially while compiling with Swift 5.2.

Modifications:

- Change: `init(exactly)` to be `init<T: BinaryInteger)(minorUnits:)` to be more forgiving to the types, and to avoid confusion with `Numeric` initializers
- Change: `init(_:)` to be `init?(amount:)` to properly handle NaN values as well as to avoid `init(floatLiteral:)` accidental usage due to SE-0213
- Change: Code documentation to be more thorough and clear
- Change: `inverse` from a computed property to `negated()`, catching overflow
- Change: Localization from string interpolation is now explicit with `\(localize: <value>)` as the new form, to avoid clashes with the default interpolation behavior and default parameters

Result:

Implementations should be less buggy, Currency should compile in Swift 5+, with happier developers using the library.