### PR TITLE
Change Package name from `swift-currency` to `Currency`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Generate report
       run: |
         xcrun llvm-cov show \
-          .build/x86_64-apple-macosx/debug/swift-currencyPackageTests.xctest/Contents/MacOS/swift-currencyPackageTests \
+          .build/x86_64-apple-macosx/debug/currencyPackageTests.xctest/Contents/MacOS/currencyPackageTests \
           -instr-profile=".build/x86_64-apple-macosx/debug/codecov/default.profdata" \
           -ignore-filename-regex="(.build|Tests|ISOCurrencies)" > coverage.txt
     - name: Upload report

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "swift-currency",
+    name: "Currency",
     products: [
         .library(name: "Currency", targets: ["Currency"]),
     ],


### PR DESCRIPTION
Motivation:

On the forums https://forums.swift.org/t/swift-package-naming-conventions/33931 it was discussed as to the preferred package naming conventions
in the ecosystem, for the future when Swift has a Package Index / Registry.

Modification:

- Rename: Package.name from `swift-currency` to `Currency`

Result:

The repository is named `swift-currency` while the overall package is `Currency`, and the main product is also `Currency`