### PR TITLE
Improve the performance of * and / operators

### DIFF
--- a/Sources/Currency/AnyCurrency.swift
+++ b/Sources/Currency/AnyCurrency.swift
@@ -123,11 +123,14 @@ extension AnyCurrency {
   }
 
   public static func *(lhs: Self, rhs: Self) -> Self {
-    return Self(scalingAndRounding: lhs.amount * rhs.amount)
+    let result = Double(lhs.minorUnits * rhs.minorUnits) / pow(10, Double(Self.metadata.minorUnits))
+    return .init(minorUnits: Int64(result.rounded(.toNearestOrEven)))
   }
 
   public static func /(lhs: Self, rhs: Self) -> Self {
-    return Self(scalingAndRounding: lhs.amount / rhs.amount)
+    let quotent = Double(lhs.minorUnits) / .init(rhs.minorUnits)
+    let result = quotent * pow(10, Double(Self.metadata.minorUnits))
+    return .init(minorUnits: Int64(result.rounded(.toNearestOrEven)))
   }
 
   public static func +=(lhs: inout Self, rhs: Self) { lhs = lhs + rhs }

--- a/Tests/CurrencyTests/AnyCurrencyTests.swift
+++ b/Tests/CurrencyTests/AnyCurrencyTests.swift
@@ -214,20 +214,20 @@ extension AnyCurrencyTests {
 
   func testDivision() {
     let first = USD(300.12)
-    XCTAssertEqual(first / USD(30), 10)
+    XCTAssertEqual(first / USD(30.198), 9.94)
 
     var second = USD(32.12)
-    second /= USD(45)
+    second /= USD(45.2)
     XCTAssertEqual(second.amount, 0.71)
   }
   
   func testMultiplication() {
     let first = USD(300.12)
-    XCTAssertEqual(first * USD(30), 9003.6)
+    XCTAssertEqual(first * USD(0.309), 93.04)
 
     var second = USD(32.12)
-    second *= USD(45)
-    XCTAssertEqual(second.amount, 1445.4)
+    second *= USD(45.2)
+    XCTAssertEqual(second.amount, 1451.82)
   }
 
   func testNegation() {


### PR DESCRIPTION
Motivation:

The current implementation of the multiplicative arithmetic operators is naive, as it converts the `minorUnits`
into a Decimal representation, applies the artihmetic, then does a conversion back to `minorUnits`.

This can be improved with conversions to both Double, and by doing the arithmetic directly.

Modifications:

- Change: * and / operators to do conversions to Double instead of Decimal, and inline the arithmetic operations needed

Result:

Performing multiplicative arithmetic against currencies should be much faster now. (XCTest `measure` reports 50% improvement)