### PR TITLE
Re-implement the basic concept of 'Currency' with Decimal storage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{h,m}]
+indent_size = 4
+
+[*.md]
+indent_size = 4

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Currency/Currency+Algorithms.swift
+++ b/Sources/Currency/Currency+Algorithms.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// MARK: Even Distribution
+
+extension Currency {
+  /// Distributes the current amount into a set number of parts as evenly as possible.
+  ///
+  /// After splitting the amount evenly, any remainder will be given to the first value in the result collection.
+  /// - Note: Passing a negative or `0` value will result in an empty result.
+  /// - Complexity: O(1)
+  /// - Parameter numParts: The count of new values the single value should be distributed between as evenly as possible.
+  /// - Returns: A collection of currency values with their share of the amount distribution.
+  public func distributedEvenly(intoParts numParts: Int) -> [Self] {
+    guard numParts > 0 else { return [] }
+
+    let count = CurrencyMinorUnitRepresentation(numParts)
+
+    let units = self.minorUnits
+    let fraction = units / count
+    let remainder = Int(abs(units) % count)
+
+    let remainderCollection: [Self] = .init(repeating: Self(minorUnits: fraction + units.signum()), count: remainder)
+    let distributedCollection: [Self] = .init(repeating: Self(minorUnits: fraction), count: numParts - remainder)
+    return remainderCollection + distributedCollection
+  }
+}

--- a/Sources/Currency/Currency+Arithmetic.swift
+++ b/Sources/Currency/Currency+Arithmetic.swift
@@ -1,0 +1,234 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// MARK: Identity
+
+extension Currency {
+  /// The zero value.
+  ///
+  /// Zero is the identity element for addition. For any value,
+  /// `x + .zero == x` and `.zero + x == x`.
+  @inlinable
+  public static var zero: Self { return Self(exactAmount: .zero) }
+
+  /// Returns the current value as its additive inverse.
+  ///
+  /// The following example uses the `negated()` method to negate the currency value:
+  ///
+  ///     let negativeAmount = USD(3.40).negated()
+  ///     // negativeAmount == USD(-3.40)
+  /// - Complexity: O(1)
+  @inlinable
+  public func negated() -> Self {
+    return Self(exactAmount: self.exactAmount * -1)
+  }
+}
+
+// MARK: Addition
+
+extension Currency {
+  // perhaps convert to minor units, multiply, then convert back to decimal?
+
+  public static func +(lhs: Self, rhs: Self) -> Self {
+    return .init(exactAmount: lhs.exactAmount + rhs.exactAmount)
+  }
+  public static func +=(lhs: inout Self, rhs: Self) { lhs = lhs + rhs }
+
+  /// Adds the given other amount to the current exactAmount.
+  /// - Parameter amount: The other amount to add.
+  @inlinable
+  public mutating func add(_ amount: Self) {
+    self += amount
+  }
+  /// Adds the other amount to the current exactAmount as a new value.
+  /// - Parameter amount: The other amount to add.
+  public func adding(_ amount: Self) -> Self {
+    return self + amount
+  }
+
+  public static func +(lhs: Self, rhs: some BinaryInteger) -> Self {
+    guard let rhs = Decimal(exactly: rhs) else {
+      return .init(exactAmount: .nan)
+    }
+    return .init(exactAmount: lhs.exactAmount + rhs)
+  }
+  public static func +=(lhs: inout Self, rhs: some BinaryInteger) { lhs = lhs + rhs }
+
+  /// Adds the given other amount to the current exactAmount.
+  /// - Parameter amount: The other amount to add.
+  @inlinable
+  public mutating func add(_ amount: some BinaryInteger) {
+    self += amount
+  }
+  /// Adds the other amount to the current exactAmount as a new value.
+  /// - Parameter amount: The other amount to add.
+  public func adding(_ amount: some BinaryInteger) -> Self {
+    return self + amount
+  }
+
+  public static func +(lhs: Self, rhs: Decimal) -> Self {
+    return .init(exactAmount: lhs.exactAmount + rhs)
+  }
+  public static func +=(lhs: inout Self, rhs: Decimal) { lhs = lhs + rhs }
+
+  /// Adds the given other amount to the current exactAmount.
+  /// - Parameter amount: The other amount to add.
+  @inlinable
+  public mutating func add(_ amount: Decimal) {
+    self += amount
+  }
+  /// Adds the other amount to the current exactAmount as a new value.
+  /// - Parameter amount: The other amount to add.
+  public func adding(_ amount: Decimal) -> Self {
+    return self + amount
+  }
+}
+
+// MARK: Subtraction
+
+extension Currency {
+  // perhaps convert to minor units, multiply, then convert back to decimal?
+
+  public static func -(lhs: Self, rhs: Self) -> Self {
+    return .init(exactAmount: lhs.exactAmount - rhs.exactAmount)
+  }
+  public static func -=(lhs: inout Self, rhs: Self) { lhs = lhs - rhs }
+
+  /// Subtracts the given other amount from the current exactAmount.
+  /// - Parameter amount: The other amount to subtract.
+  public mutating func subtract(_ amount: Self) {
+    self -= amount
+  }
+  /// Subtracts the other amount from the current exactAmount as a new value.
+  /// - Parameter amount: The other amount to subtract.
+  public func subtracting(_ amount: Self) -> Self {
+    return self - amount
+  }
+
+  public static func -(lhs: Self, rhs: some BinaryInteger) -> Self {
+    guard let rhs = Decimal(exactly: rhs) else {
+      return .init(exactAmount: .nan)
+    }
+    return .init(exactAmount: lhs.exactAmount - rhs)
+  }
+  public static func -=(lhs: inout Self, rhs: some BinaryInteger) { lhs = lhs - rhs }
+
+  /// Subtracts the given other amount from the current exactAmount.
+  /// - Parameter amount: The other amount to subtract.
+  public mutating func subtract(_ amount: some BinaryInteger) {
+    self -= amount
+  }
+  /// Subtracts the other amount from the current exactAmount as a new value.
+  /// - Parameter amount: The other amount to subtract.
+  public func subtracting(_ amount: some BinaryInteger) -> Self {
+    return self - amount
+  }
+
+  public static func -(lhs: Self, rhs: Decimal) -> Self {
+    return .init(exactAmount: lhs.exactAmount - rhs)
+  }
+  public static func -=(lhs: inout Self, rhs: Decimal) { lhs = lhs - rhs }
+
+  /// Subtracts the given other amount from the current exactAmount.
+  /// - Parameter amount: The other amount to subtract.
+  public mutating func subtract(_ amount: Decimal) {
+    self -= amount
+  }
+  /// Subtracts the other amount from the current exactAmount as a new value.
+  /// - Parameter amount: The other amount to subtract.
+  public func subtracting(_ amount: Decimal) -> Self {
+    return self - amount
+  }
+}
+
+//  MARK: Multiplication
+
+extension Currency {
+  // perhaps convert to minor units, multiply, then convert back to decimal?
+  // let result = Double(lhs.minorUnits * rhs.minorUnits) / pow(10, Double(Self.metadata.minorUnits))
+
+  public static func *(lhs: Self, rhs: some BinaryInteger) -> Self {
+    guard let rhs = Decimal(exactly: rhs) else {
+      return .init(exactAmount: .nan)
+    }
+    return .init(exactAmount: lhs.exactAmount * rhs)
+  }
+  public static func *=(lhs: inout Self, rhs: some BinaryInteger) { lhs = lhs * rhs }
+
+  /// Multiplies the current exactAmount by the given other amount.
+  /// - Parameter amount: The other amount to multiply by.
+  public mutating func multiply(by amount: some BinaryInteger) {
+    self *= amount
+  }
+  /// Multiplies the current exactAmount by the other amount as a new value.
+  /// - Parameter amount: The other amount to multiply by.
+  public func multiplying(by amount: some BinaryInteger) -> Self {
+    return self * amount
+  }
+
+  public static func *(lhs: Self, rhs: Decimal) -> Self {
+    return .init(exactAmount: lhs.exactAmount * rhs)
+  }
+  public static func *=(lhs: inout Self, rhs: Decimal) { lhs = lhs * rhs }
+
+  /// Multiplies the current exactAmount by the given other amount.
+  /// - Parameter amount: The other amount to multiply by.
+  public mutating func multiply(by amount: Decimal) {
+    self *= amount
+  }
+  /// Multiplies the current exactAmount by the other amount as a new value.
+  /// - Parameter amount: The other amount to multiply by.
+  public func multiplying(by amount: Decimal) -> Self {
+    return self * amount
+  }
+}
+
+// MARK: Division
+
+extension Currency {
+  // perhaps convert to minor units, multiply, then convert back to decimal?
+  // let quotent = Double(lhs.minorUnits) / .init(rhs.minorUnits)
+  // let result = quotent * pow(10, Double(Self.metadata.minorUnits))
+
+  public static func /(lhs: Self, rhs: some BinaryInteger) -> Self {
+    guard let rhs = Decimal(exactly: rhs) else {
+      return .init(exactAmount: .nan)
+    }
+    return lhs / rhs
+  }
+  public static func /=(lhs: inout Self, rhs: some BinaryInteger) { lhs = lhs / rhs }
+
+  @inlinable
+  public mutating func divide(by amount: some BinaryInteger) {
+    self /= amount
+  }
+  public func dividing(by amount: some BinaryInteger) -> Self {
+    return self / amount
+  }
+
+  public static func /(lhs: Self, rhs: Decimal) -> Self {
+    return .init(exactAmount: lhs.exactAmount / rhs)
+  }
+  public static func /=(lhs: inout Self, rhs: Decimal) { lhs = lhs / rhs }
+
+  @inlinable
+  public mutating func divide(by amount: Decimal) {
+    self /= amount
+  }
+  public func dividing(by amount: Decimal) -> Self {
+    return self / amount
+  }
+}

--- a/Sources/Currency/Currency+StringRepresentation.swift
+++ b/Sources/Currency/Currency+StringRepresentation.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.Locale
+import class Foundation.NumberFormatter
+import class Foundation.NSDecimalNumber
+
+// price.description                    3000.98 USD
+// price.debugDescription           USD(3000.98)
+// price.playgroundDescription      USD(3000.98)
+// "\(localize: price)"               $3,000.98
+// "\(localize: price, with: ...)"    $3,000.98
+// "\(localize: price, for: ...)"     $3,000.98
+
+// MARK: CustomStringConvertible
+
+extension Currency {
+  public var description: String { "\(self.exactAmount) \(Self.descriptor.alphabeticCode)"}
+  public var debugDescription: String {
+    "\(Self.descriptor.alphabeticCode)(exact: \(self.exactAmount.description), minorUnits: \(self.minorUnits)"
+  }
+  public var playgroundDescription: Any { self.debugDescription }
+}
+
+// MARK: Localization
+
+extension String.StringInterpolation {
+  /// Creates a string representation of the currency value, localized to a particular locale.
+  ///
+  /// Example
+  ///
+  ///       let pounds = GBP(30.03)
+  ///       let localizedString = "\(localize: pounds, for: Locale(identifier: "de_DE"))"
+  ///       print(localizedString)
+  ///       // 30,03 £
+  ///       print("\(localize: pounds)")
+  ///       // £30.03, assuming `Locale.current` is "en_US"
+  ///
+  /// This can also be done with a method on the value itself:
+  ///
+  ///       let usd = USD(30.03)
+  ///       print(usd.localizedString(for: .init(identifier: "fr_FR")))
+  ///       // 30,03 $US
+  ///       print(usd.localizedString())
+  ///       // $30.03, assuming `Locale.current` is "en_US"
+  ///
+  /// - Important: This creates a new `NumberFormatter` every time it is called.
+  /// If you have a cached instance, use `(localize:with:nilDescription:)` instead.
+  /// - Parameters:
+  ///   - value: The value to localize. If the value is `nil`, then the `nilDescription` will be used.
+  ///   - locale: The Locale to localize the value for. The default is `.current`, ig. the runtime environment's Locale.
+  ///   - nilDescription: The optional description to use when the `value` is `nil`.
+  public mutating func appendInterpolation<C: Currency>(
+    localize value: C?,
+    for locale: Locale = .current,
+    nilDescription: String = "nil"
+  ) {
+    guard case let .some(value) = value else { return nilDescription.write(to: &self) }
+
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.locale = locale
+    formatter.currencyCode = C.descriptor.alphabeticCode
+
+    self.appendInterpolation(localize: value, with: formatter, nilDescription: nilDescription)
+  }
+
+  /// Creates a string representation of the currency value, using the provided formatter.
+  ///
+  ///       let formatter = ...
+  ///       let currency = ...
+  ///       let localizedString = "\(localize: currency, with: formatter)"
+  ///
+  /// This can also be done with a method on the value itself:
+  ///
+  ///       let formatter = NumberFormatter()
+  ///       formatter.numberStyle = .currency
+  ///       formatter.currencyGroupingSeparator = " "
+  ///       formatter.currencyDecimalSeparator = "'"
+  ///       formatter.currencyCode = "GBP"
+  ///
+  ///       let pounds = GBP(14928.02)
+  ///       print(pounds.localizedString(using: formatter))
+  ///       // £14 928'02
+  ///
+  /// - Important: This method does not modify the given `Foundation.NumberFormatter`.
+  /// If the same formatter is to be used for different currencies,
+  /// the property will need to be updated before calling this method.
+  /// - Parameters:
+  ///   - value: The value to localize. If the value is `nil`, then the `nilDescription` will be used.
+  ///   - formatter: The pre-configured formatter to use.
+  ///   - nilDescription: The optional description to use when the `value` is `nil`.
+  public mutating func appendInterpolation<C: Currency>(
+    localize value: C?,
+    with formatter: NumberFormatter,
+    nilDescription: String = "nil"
+  ) {
+    guard case let .some(value) = value else { return nilDescription.write(to: &self) }
+
+    guard let localizedString = formatter.string(from: value.exactAmount as NSDecimalNumber) else {
+      nilDescription.write(to: &self)
+      return
+    }
+
+    localizedString.write(to: &self)
+  }
+}
+
+extension Currency {
+  /// Creates a string representation of the currency value, localized to a particular locale.
+  ///
+  ///       let usd = USD(30.03)
+  ///       print(usd.localizedString(for: .init(identifier: "fr_FR")))
+  ///       // 30,03 $US
+  ///       print(usd.localizedString())
+  ///       // $30.03, assuming `Locale.current` is "en_US"
+  ///
+  /// This can also be done with String interpolation:
+  ///
+  ///       let pounds = GBP(30.03)
+  ///       let localizedString = "\(localize: pounds, for: Locale(identifier: "de_DE"))"
+  ///       print(localizedString)
+  ///       // 30,03 £
+  ///       print("\(localize: pounds)")
+  ///       // £30.03, assuming `Locale.current` is "en_US"
+  ///
+  /// - Parameters:
+  ///   - locale: The Locale to localize the value for. The default is `.current`, ig. the runtime environment's Locale.
+  /// - Returns: A localized String representation of the currency value.
+  public func localizedString(for locale: Locale = .current) -> String {
+    return "\(localize: self, for: locale)"
+  }
+
+  /// Creates a string representation of the currency value, using the provided formatter.
+  ///
+  ///      let formatter = NumberFormatter()
+  ///      formatter.numberStyle = .currency
+  ///      formatter.currencyGroupingSeparator = " "
+  ///      formatter.currencyDecimalSeparator = "'"
+  ///      formatter.currencyCode = "GBP"
+  ///
+  ///      let pounds = GBP(14928.02)
+  ///      print(pounds.localizedString(using: formatter))
+  ///      // £14 928'02
+  ///
+  /// This can also be done with String interpolation:
+  ///
+  ///       let formatter = ...
+  ///       let currency = ...
+  ///       let localizedString = "\(localize: currency, with: formatter)"
+  ///
+  /// - Important: This method does not modify the given `Foundation.NumberFormatter`.
+  /// If the same formatter is to be used for different currencies, the property will need to be updated before calling this method.
+  /// - Parameters:
+  ///   - formatter: The pre-configured formatter to use.
+  /// - Returns: A localized String representation of the currency value.
+  public func localizedString(using formatter: NumberFormatter) -> String {
+    return "\(localize: self, with: formatter)"
+  }
+}

--- a/Sources/Currency/Currency.swift
+++ b/Sources/Currency/Currency.swift
@@ -27,8 +27,8 @@ import func Foundation.NSDecimalRound
 ///
 /// _Equality comparisons and most arithmetic operations use this value._
 public protocol Currency:
-//  CustomStringConvertible, CustomDebugStringConvertible, CustomPlaygroundDisplayConvertible,
-  CustomLeafReflectable,
+  CustomStringConvertible, CustomDebugStringConvertible, CustomPlaygroundDisplayConvertible,
+  CustomReflectable,
   Comparable, Hashable,
   ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral
 {

--- a/Sources/Currency/Currency.swift
+++ b/Sources/Currency/Currency.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.Decimal
+import class Foundation.NSDecimalNumber
+import func Foundation.NSDecimalRound
+
+/// A monetary numeric value representing a currency.
+///
+/// **Value Representation**
+///
+/// All currencies have a "minorUnits" scale, as defined by their ``CurrencyDescriptor``
+/// that determine their precision when represented as a `Foundation.Decimal`.
+///
+/// For example, as the USD uses 1/100 for its minor unit, with the value `USD(1.0)`, `minorUnits` will be the value `100`.
+///
+/// _Equality comparisons and most arithmetic operations use this value._
+public protocol Currency:
+//  CustomStringConvertible, CustomDebugStringConvertible, CustomPlaygroundDisplayConvertible,
+  CustomLeafReflectable,
+  Comparable, Hashable,
+  ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral
+{
+  /// The information describing the currency.
+  static var descriptor: CurrencyDescriptor.Type { get }
+
+  /// The amount represented as a whole number of the curreny's "minor units".
+  ///
+  /// For example, as the USD uses 1/100 for its minor unit,
+  /// with the value of `USD 1.01`, ``minorUnits`` will be the value `101`.
+  /// - Important: Fractional values (of the currency) are impossible to be represented in this value.
+  var minorUnits: CurrencyMinorUnitRepresentation { get }
+
+  /// The exact amount of money being represented,
+  /// even if the value is fractional of what the currency uses for its minor units.
+  ///
+  /// e.g. If the the currency is `USD` which uses 2 minor units (1/100th), the ``exactAmount`` may be `2.00389`.
+  ///
+  /// For an amount that is likely to be used in "every day" usage, see ``roundedAmount``
+  var exactAmount: Decimal { get }
+
+  /// The cannonical representation of the ``exactAmount`` of money this value represents,
+  /// rounded using the `bankers` method to the currency's ``CurrencyDescriptor/minorUnits``.
+  ///
+  /// For example:
+  ///
+  ///     let usd = USD(10.007)
+  ///     let yen = JPY(100.9)
+  ///     let dinar = KWD(100.0019)
+  ///     print(usd, yen, dinar)
+  ///     // "USD(10.01), JPY(101), KWD(100.002)
+  var roundedAmount: Decimal { get }
+
+  /// Creates a representation of the currency with the exact value as given.
+  /// - Parameter exactAmount: The amount this instance should represent, without any rounding.
+  init(exactAmount: Decimal)
+
+  /// Creates a representation of the currency, converting the minor units representation to a decimal format.
+  ///
+  /// e.g. If you provide the value `100` for a currency with `2` minor units, the `exactAmount` will be `1.00`.
+  /// - Parameter minorUnits: The minor units this value will represent.
+  init(minorUnits: CurrencyMinorUnitRepresentation)
+
+  /// Rounds the ``exactAmount`` of money being represented using the given rounding method
+  /// to the currency's ``CurrencyDescriptor/minorUnits``.
+  /// - Parameter roundingMode: The desired rounding mode to use on the original ``exactAmount``.
+  /// - Complexity: O(1)
+  /// - Returns: The rounded amount.
+  func roundedAmount(using roundingMode: NSDecimalNumber.RoundingMode) -> Decimal
+}
+
+// MARK: Defaults
+
+extension Currency {
+  public var minorUnits: CurrencyMinorUnitRepresentation {
+    let scaledAmount = self.exactAmount * Self.descriptor.minorUnitsCoefficient(for: .exactAmount)
+    return .init(scaledAmount.int64Value)
+  }
+
+  public var roundedAmount: Decimal { self.roundedAmount(using: .bankers) }
+
+  public init(minorUnits: CurrencyMinorUnitRepresentation) {
+    let amount = Decimal(minorUnits) * Self.descriptor.minorUnitsCoefficient(for: .minorUnits)
+    self.init(exactAmount: amount)
+  }
+
+  public func roundedAmount(using roundingMode: NSDecimalNumber.RoundingMode) -> Decimal {
+    var sourceAmount = self.exactAmount
+    var result = Decimal.zero
+    NSDecimalRound(&result, &sourceAmount, .init(Self.descriptor.minorUnits), roundingMode)
+    return result
+  }
+}
+
+extension Currency where Self: CurrencyDescriptor {
+  public static var descriptor: CurrencyDescriptor.Type { Self.self }
+}
+
+// MARK: Equatable
+
+extension Currency {
+  public static func ==<Other: Currency>(lhs: Self, rhs: Other) -> Bool {
+    guard Self.descriptor == Other.descriptor else { return false }
+    return lhs.exactAmount == rhs.exactAmount
+  }
+}
+
+// MARK: Comparable
+
+extension Currency {
+  public static func < <Other: Currency>(lhs: Self, rhs: Other) -> Bool {
+    guard Self.descriptor == Other.descriptor else {
+      return Self.descriptor.alphabeticCode < Other.descriptor.alphabeticCode
+    }
+    return lhs.exactAmount < rhs.exactAmount
+  }
+}
+
+// MARK: Hashable
+
+extension Currency {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(Self.descriptor))
+    hasher.combine(self.exactAmount)
+  }
+}
+
+// MARK: CustomReflectable
+
+extension Currency {
+  public var customMirror: Mirror {
+    return .init(self, children: [
+      "exactAmount": self.exactAmount,
+      "minorUnits": self.minorUnits,
+      "descriptor": Self.descriptor
+    ])
+  }
+}
+
+// MARK: Literal Representations
+
+extension Currency {
+  public init(floatLiteral value: Double) {
+    self.init(exactAmount: Decimal(value))
+  }
+
+  public init(integerLiteral value: Int) {
+    self.init(exactAmount: Decimal(value))
+  }
+}

--- a/Sources/Currency/CurrencyDescriptor.swift
+++ b/Sources/Currency/CurrencyDescriptor.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2020 SwiftCurrency project authors
+// Copyright (c) 2024 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -12,8 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type that provides static currency information as defined by ISO 4217.
-public protocol CurrencyMetadata {
+import struct Foundation.Decimal
+
+/// A type that provides information describing a currency in terms as defined by ISO 4217.
+public protocol CurrencyDescriptor {
   /// The name of the currency, such as "United States Dollar".
   static var name: String { get }
   /// The ISO 4217 3-digit letter currency code.
@@ -32,4 +34,24 @@ public protocol CurrencyMetadata {
   ///
   /// However, the Japanese Yen has no minor unit, so it has `0` minorUnits.
   static var minorUnits: UInt8 { get }
+}
+
+public typealias CurrencyMetadata = CurrencyDescriptor
+
+// MARK: Minor Units conversions
+
+@usableFromInline
+internal enum CurrencyMinorUnitConversionSource {
+  case minorUnits, exactAmount
+}
+
+extension CurrencyDescriptor {
+  internal static func minorUnitsCoefficient(for source: CurrencyMinorUnitConversionSource) -> Decimal {
+    let exponent: Int
+    switch source {
+    case .exactAmount: exponent = .init(Self.minorUnits)
+    case .minorUnits: exponent = -.init(Self.minorUnits)
+    }
+    return .init(sign: .plus, exponent: exponent, significand: 1)
+  }
 }

--- a/Sources/Currency/Extensions/Sequence+Currency.swift
+++ b/Sources/Currency/Extensions/Sequence+Currency.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: Sum
+
+extension Sequence where Element: Currency {
+  /// Returns the sum total of all amounts in the sequence.
+  ///
+  /// For example:
+  ///
+  ///     let amounts: [USD] = [304.98, 19.02]
+  ///     let sumTotal = amounts.sum()
+  ///     print(sumTotal)
+  ///     // prints "324"
+  ///
+  /// If the sequence has no elements, you will receive a currency with a value of "0".
+  /// - Complexity: O(*n*) , where *n* is the length of the sequence.
+  /// - Returns: A currency value representing the sum total of all the amounts in the sequence.
+  public func sum() -> Element {
+    return self.reduce(into: .zero, +=)
+  }
+
+  /// Returns the sum total of all amounts in the sequence that satify the given predicate.
+  /// For example:
+  ///
+  ///     let amounts: [USD] = [304.98, 19.02, 30.21]
+  ///     let sumTotal = amounts.sum(where: { $0.amount > 20 })
+  ///     print(sumTotal)
+  ///     // prints "335.19"
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the sequence.
+  /// - Parameter isIncluded: A closure that takes a currency element as its argument
+  ///   and returns a Boolean value that indicates whether the passed element should be included in the sum.
+  /// - Returns: A currency value representing the sum total of all the amounts `isIncluded` allowed.
+  @inlinable
+  public func sum(where isIncluded: (Element) throws -> Bool) rethrows -> Element {
+    return try self.reduce(into: .zero) { result, next in
+      guard try isIncluded(next) else { return }
+      result += next
+    }
+  }
+
+  /// Returns the sum total of amounts in the sequence after applying the provided transform.
+  ///
+  /// Rather than doing a `.map(_:)` and then `.sum()`, the `sum` result will be calculated inline while applying the transformations.
+  ///
+  /// For example, you may want to calculate what the total taxes would be from a sequence of individual prices:
+  ///
+  ///     let prices: [USD] = [3.00, 2.99, 5.98]
+  ///     // apply a 9% tax rate to each price and calculate the sum
+  ///     let totalTaxes = prices.sum { $0 * Decimal(0.09) }
+  ///     // totalTaxes == USD(1.08)
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the sequence.
+  /// - Parameter transform: A mapping closure. `transform` accepts an element of this sequence as its parameter
+  /// and returns a transformed value of the same type.
+  /// - Returns: A currency value representing the sum total of all the transformed amounts in the sequence.
+  @inlinable
+  public func sum(_ transform: (Element) throws -> (Element)) rethrows -> Element {
+    return try self.reduce(into: .zero) { $0 += try transform($1) }
+  }
+}

--- a/Sources/Currency/MinorUnitRepresentation.swift
+++ b/Sources/Currency/MinorUnitRepresentation.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// The integer used to represent a currency in it's 'minor units' form.
+/// e.g. 100 USD will be represented as `100`.
+///
+/// Converting from minor units to its decimal form is lossless, as you can multiply or divide
+/// by the currency's `minorUnits` value.
+public typealias CurrencyMinorUnitRepresentation = Int64

--- a/Sources/ISOStandardCodegen/ISOCurrencyGeneration.swift
+++ b/Sources/ISOStandardCodegen/ISOCurrencyGeneration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2022 SwiftCurrency project authors
+// Copyright (c) 2024 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -16,7 +16,10 @@ import Foundation
 
 func makeISOCurrencyDefinitionFile(at destinationURL: URL, from metadata: [CurrencyMetadata]) throws {
   let typeDefinitions = makeTypeDefinitions(from: metadata)
-  let fileContent = makeFileContent(withBody: typeDefinitions.joined(separator: "\n\n"))
+  let fileContent = makeFileContent(
+    withBody: "import struct Foundation.Decimal\n\n"
+      .appending(typeDefinitions.joined(separator: "\n\n"))
+  )
 
   try fileContent.write(to: destinationURL, atomically: true, encoding: .utf8)
 }
@@ -61,6 +64,18 @@ private func makeTypeDefinitions(from metadata: [CurrencyMetadata]) -> [String] 
       private let _minorUnits: Int64
 
       public init<T: BinaryInteger>(minorUnits: T) { self._minorUnits = .init(minorUnits) }
+    }
+            
+    \(summary)
+    public struct _New_\(definition.identifiers.alphabetic): Currency, CurrencyDescriptor {
+      public static var name: String { "\(definition.name)" }
+      public static var alphabeticCode: String { "\(definition.identifiers.alphabetic)" }
+      public static var numericCode: UInt16 { \(definition.identifiers.numeric) }
+      public static var minorUnits: UInt8 { \(definition.minorUnits) }
+
+      public let exactAmount: Decimal
+
+      public init(exactAmount: Decimal) { self.exactAmount = exactAmount }
     }
     """
   }

--- a/Tests/CurrencyTests/Currency+AlgorithmsTests.swift
+++ b/Tests/CurrencyTests/Currency+AlgorithmsTests.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Currency
+import XCTest
+
+final class CurrencyAlgorithmsTests: XCTestCase { }
+
+// MARK: Distributed Evenly
+
+extension CurrencyAlgorithmsTests {
+  func test_distributedEvenly_with0_orNegative_NumParts_returnsEmptyResult() {
+    let value = _New_USD(5)
+    XCTAssertTrue(value.distributedEvenly(intoParts: 0).isEmpty)
+    XCTAssertTrue(value.distributedEvenly(intoParts: -1).isEmpty)
+  }
+
+  func test_distributedEvenly_with0MinorUnits() {
+    self.run_distributedEvenlyTest(
+      for: _New_JPY(10.05),
+      numParts: 6,
+      expectedResults: .init(repeating: _New_JPY(2), count: 4) + .init(repeating: _New_JPY(1), count: 2)
+    )
+  }
+
+  func test_distributedEvenly_with1MinorUnit() {
+    self.run_distributedEvenlyTest(
+      for: _New_XTS(10.05),
+      numParts: 6,
+      expectedResults: .init(repeating: _New_XTS(1.7), count: 4) + .init(repeating: _New_XTS(1.6), count: 2)
+    )
+  }
+
+  func test_distributedEvenly_with2MinorUnit() {
+    self.run_distributedEvenlyTest(
+      for: _New_USD(15.01),
+      numParts: 3,
+      expectedResults: [_New_USD(exactAmount: Decimal(string: "5.01")!), 5, 5]
+    )
+    self.run_distributedEvenlyTest(
+      for: _New_USD(10.05),
+      numParts: 6,
+      expectedResults: .init(repeating: _New_USD(1.68), count: 3) + .init(repeating: _New_USD(1.67), count: 3)
+    )
+  }
+
+  func test_distributedEvenly_with3MinorUnit() {
+    self.run_distributedEvenlyTest(
+      for: _New_KWD(10.05),
+      numParts: 6,
+      expectedResults: .init(repeating: _New_KWD(1.675), count: 6)
+    )
+  }
+
+  private func run_distributedEvenlyTest<C: Currency>(
+    for currency: C,
+    numParts count: Int,
+    expectedResults: [C],
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard count == expectedResults.count else {
+      return XCTFail(
+        "Inconsistent desire: Asked for \(count) parts, but expect \(expectedResults.count) results",
+        file: file, line: line
+      )
+    }
+    let actualResults = currency.distributedEvenly(intoParts: count)
+    XCTAssertEqual(actualResults, expectedResults, file: file, line: line)
+    XCTAssertEqual(currency.roundedAmount, expectedResults.sum().roundedAmount, file: file, line: line)
+    XCTAssertEqual(
+      currency.negated().distributedEvenly(intoParts: count),
+      expectedResults.map({ $0.negated() }),
+      file: file, line: line
+    )
+  }
+}

--- a/Tests/CurrencyTests/Currency+ArithmeticTests.swift
+++ b/Tests/CurrencyTests/Currency+ArithmeticTests.swift
@@ -1,0 +1,528 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Currency
+import XCTest
+
+final class CurrencyArithmeticTests: XCTestCase { }
+
+// MARK: Identity
+
+extension CurrencyArithmeticTests {
+  func test_zero_equalsDecimalZero() {
+    XCTAssertTrue(_New_USD.zero.exactAmount == .zero)
+    XCTAssertTrue(_New_JPY.zero.exactAmount == .zero)
+    XCTAssertTrue(_New_KWD.zero.exactAmount == .zero)
+  }
+
+  func test_negated_correctlyInvertsValues() {
+    func assertNegationIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let positive = currencyType.init(exactAmount: 30.03)
+      XCTAssertEqual(
+        positive.negated(),
+        currencyType.init(exactAmount: -30.03),
+        "positive to negative failed",
+        file: file, line: line
+      )
+
+      let negative = currencyType.init(exactAmount: -41.21)
+      XCTAssertEqual(
+        negative.negated(),
+        currencyType.init(exactAmount: 41.21),
+        "negative to positive failed",
+        file: file, line: line
+      )
+    }
+
+    assertNegationIsCorrect(for: _New_USD.self)
+    assertNegationIsCorrect(for: _New_JPY.self)
+    assertNegationIsCorrect(for: _New_KWD.self)
+  }
+}
+
+// MARK: Addition
+
+extension CurrencyArithmeticTests {
+  func test_addition_withSelf_isCorrect() {
+    func assertAdditionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first + currencyType.init(exactAmount: 30.01),
+        currencyType.init(exactAmount: 330.13),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.adding(.init(exactAmount: 45)),
+        currencyType.init(exactAmount: 77.12),
+        "adding(_:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.add(.init(exactAmount: 30))
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "62.12")!),
+        "add(_:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertAdditionIsCorrect(for: _New_USD.self)
+    assertAdditionIsCorrect(for: _New_JPY.self)
+    assertAdditionIsCorrect(for: _New_KWD.self)
+  }
+
+  func test_addition_withBinaryInteger_isCorrect() {
+    func assertAdditionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first + (30 as Int),
+        currencyType.init(exactAmount: 330.12),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.adding(45 as Int),
+        currencyType.init(exactAmount: 77.12),
+        "adding(_:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.add(30 as Int)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "62.12")!),
+        "add(_:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertAdditionIsCorrect(for: _New_USD.self)
+    assertAdditionIsCorrect(for: _New_JPY.self)
+    assertAdditionIsCorrect(for: _New_KWD.self)
+  }
+
+  func test_addition_withDecimal_isCorrect() {
+    func assertAdditionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first + (30 as Decimal),
+        currencyType.init(exactAmount: 330.12),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.adding(45 as Decimal),
+        currencyType.init(exactAmount: 77.12),
+        "adding(_:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.add(30.01 as Decimal)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "62.13")!),
+        "add(_:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertAdditionIsCorrect(for: _New_USD.self)
+    assertAdditionIsCorrect(for: _New_JPY.self)
+    assertAdditionIsCorrect(for: _New_KWD.self)
+  }
+}
+
+// MARK: Subtraction
+
+extension CurrencyArithmeticTests {
+  func test_subtraction_withSelf_isCorrect() {
+    func assertSubtractionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first - currencyType.init(exactAmount: 30.01),
+        currencyType.init(exactAmount: Decimal(string: "270.11")!),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.subtracting(.init(exactAmount: 45)),
+        currencyType.init(exactAmount: -12.88),
+        "subtracting(_:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.subtract(.init(exactAmount: 30))
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "2.12")!),
+        "subtract(_:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertSubtractionIsCorrect(for: _New_USD.self)
+    assertSubtractionIsCorrect(for: _New_JPY.self)
+    assertSubtractionIsCorrect(for: _New_KWD.self)
+  }
+
+  func test_subtraction_withBinaryInteger_isCorrect() {
+    func assertSubtractionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first - (30 as Int),
+        currencyType.init(exactAmount: 270.12),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.subtracting(45 as Int),
+        currencyType.init(exactAmount: -12.88),
+        "adding(_:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.subtract(30 as Int)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "2.12")!),
+        "add(_:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertSubtractionIsCorrect(for: _New_USD.self)
+    assertSubtractionIsCorrect(for: _New_JPY.self)
+    assertSubtractionIsCorrect(for: _New_KWD.self)
+  }
+
+  func test_subtraction_withDecimal_isCorrect() {
+    func assertSubtractionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first - (30 as Decimal),
+        currencyType.init(exactAmount: 270.12),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.subtracting(45 as Decimal),
+        currencyType.init(exactAmount: -12.88),
+        "adding(_:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.subtract(30.01 as Decimal)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "2.11")!),
+        "add(_:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertSubtractionIsCorrect(for: _New_USD.self)
+    assertSubtractionIsCorrect(for: _New_JPY.self)
+    assertSubtractionIsCorrect(for: _New_KWD.self)
+  }
+}
+
+// MARK: Multiplication
+
+extension CurrencyArithmeticTests {
+  func test_multiplication_withBinaryInteger_isCorrect() {
+    func assertMultiplicationIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first * (3 as Int),
+        currencyType.init(exactAmount: 900.36),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.multiplying(by: -3 as Int),
+        currencyType.init(exactAmount: -96.36),
+        "multiplying(by:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.multiply(by: 10 as Int)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "321.2")!),
+        "multiply(by:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertMultiplicationIsCorrect(for: _New_USD.self)
+    assertMultiplicationIsCorrect(for: _New_JPY.self)
+    assertMultiplicationIsCorrect(for: _New_KWD.self)
+  }
+
+  func test_multiplication_withDecimal_isCorrect() {
+    func assertMultiplicationIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first * (5.25 as Decimal),
+        currencyType.init(exactAmount: 1575.63),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 32.12)
+      XCTAssertEqual(
+        second.multiplying(by: -1.75 as Decimal),
+        currencyType.init(exactAmount: -56.21),
+        "multiplying(by:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.multiply(by: 7.1 as Decimal)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: 228.052),
+        "multiply(by:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertMultiplicationIsCorrect(for: _New_USD.self)
+    assertMultiplicationIsCorrect(for: _New_JPY.self)
+    assertMultiplicationIsCorrect(for: _New_KWD.self)
+  }
+}
+
+// MARK: Division
+
+extension CurrencyArithmeticTests {
+  func test_division_withBinaryInteger_isCorrect() {
+    func assertDivisionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300.12)
+      XCTAssertEqual(
+        first / (3 as Int),
+        currencyType.init(exactAmount: 100.04),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: 33.12)
+      XCTAssertEqual(
+        second.dividing(by: -3 as Int),
+        currencyType.init(exactAmount: Decimal(string: "-11.04")!),
+        "dividing(by:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.divide(by: 10 as Int)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: Decimal(string: "3.312")!),
+        "divide(by:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertDivisionIsCorrect(for: _New_USD.self)
+    assertDivisionIsCorrect(for: _New_JPY.self)
+    assertDivisionIsCorrect(for: _New_KWD.self)
+  }
+
+  func test_division_withDecimal_isCorrect() {
+    func assertDivisionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      let first = currencyType.init(exactAmount: 300)
+      XCTAssertEqual(
+        first / (2.4 as Decimal),
+        currencyType.init(exactAmount: 125),
+        "operator failed",
+        file: file, line: line
+      )
+
+      let second = currencyType.init(exactAmount: Decimal(string: "33.33")!)
+      XCTAssertEqual(
+        second.dividing(by: -1.1 as Decimal),
+        currencyType.init(exactAmount: -30.3),
+        "dividing(by:) failed",
+        file: file, line: line
+      )
+
+      var third = second
+      third.divide(by: 3.3 as Decimal)
+      XCTAssertEqual(
+        third,
+        currencyType.init(exactAmount: 10.1),
+        "divide(by:) failed",
+        file: file, line: line
+      )
+    }
+
+    assertDivisionIsCorrect(for: _New_USD.self)
+    assertDivisionIsCorrect(for: _New_JPY.self)
+    assertDivisionIsCorrect(for: _New_KWD.self)
+  }
+}
+
+// MARK: Example Usage
+
+extension CurrencyArithmeticTests {
+  func test_sampleUSDTransaction_withTaxRate_isNotMissingPennies() {
+    /*
+     original price    taxes (9%)        result
+     3.00              0.27              3.27
+     2.99              0.2691 => 0.27    3.2591 => 3.26
+     5.98              0.5382 => 0.54    6.5182 => 6.52
+     ===               ===               ===
+     11.97             1.0773 => 1.08    13.0473 => 13.05
+     */
+    let prices: [_New_USD] = [
+      3.00,
+      2.99,
+      5.98
+    ]
+
+    let subtotal = prices.sum()
+    XCTAssertEqual(subtotal.exactAmount, 11.97)
+
+    let taxes = prices.sum { $0 * 0.09 }
+    XCTAssertEqual(taxes.exactAmount, 1.0773)
+    XCTAssertEqual(taxes.roundedAmount, 1.08)
+    XCTAssertEqual(subtotal * 0.09, taxes)
+
+    let grandTotal = subtotal + taxes
+    XCTAssertEqual(grandTotal.exactAmount, 13.0473)
+    XCTAssertEqual(grandTotal.roundedAmount, 13.05)
+  }
+
+  func test_sampleUSDTransaction_withTaxRate_andDiscount_isNotMissingPennies() {
+    /* .228735
+     original price    discount (15%)    discount price      taxes (9%)          result
+     3.00              0.45              2.55                0.2295   => 0.23    2.7795    => 2.78
+     2.99              0.4485 => 0.45    2.5415 => 2.54      0.228735 => 0.23    2.770235  => 2.77
+     5.98              0.897  => 0.90    5.083  => 5.08      0.45747  => 0.46    5.54047   => 5.54
+     ===               ===               ===                 ===                 ===
+     11.97             1.7955 => 1.80    10.1745 => 10.17    0.915705 => 0.92    11.090205 => 11.09
+     */
+    let prices: [_New_USD] = [
+      3.00,
+      2.99,
+      5.98
+    ]
+
+    let discountPrices = prices.map { $0 - ($0 * 0.15) }
+
+    let discountSubtotal = discountPrices.sum()
+    XCTAssertEqual(discountSubtotal.exactAmount, 10.1745)
+    XCTAssertEqual(discountSubtotal.roundedAmount, 10.17)
+
+    let discountTaxes = discountPrices.sum { $0 * 0.09 }
+    XCTAssertEqual(discountTaxes.exactAmount, 0.915705)
+    XCTAssertEqual(discountTaxes.roundedAmount, Decimal(string: "0.92")!)
+
+    let grandTotal = discountSubtotal + discountTaxes
+    XCTAssertEqual(grandTotal.exactAmount, 11.090205)
+    XCTAssertEqual(grandTotal.roundedAmount, 11.09)
+  }
+
+  func test_sampleUSDHotelBookingTransaction() {
+    /*
+                        Decimal      |    USD (rounding at each step)
+     Base Price:        199.98       |                    199.98
+     ----
+     6% Discount:        11.9988     |     11.9988  =>     12.00
+     Running Total:     187.9812     |                    187.98
+     ----
+     9% Tax:             16.918308   |     16.9182  =>     16.92
+     Running Total:     204.899508   |                    204.90
+     ----
+     Franchise fee:       5.68       |                      5.68
+     Running Total:     210.579508   |                    210.58
+     ----
+     Total (7 days)   1,474.056556   |                  1,474.06
+     ----
+     10% Commission     147.4056556  |    147.406   =>    147.41
+     Grand Total      1,621.4622116  |  1,621.466   =>  1,621.47
+     */
+    let roomDailyRate = _New_USD(199.98)
+    let discountRate = Decimal(0.06)
+    let taxRate = Decimal(0.09)
+    let flatFranchiseFee = _New_USD(5.68)
+
+    var runningDailyTotal = roomDailyRate
+
+    // apply discount
+    let discount = roomDailyRate * discountRate
+    XCTAssertEqual(discount.roundedAmount, 12)
+    runningDailyTotal -= discount
+    XCTAssertEqual(runningDailyTotal.roundedAmount, 187.98)
+
+    // apply taxes
+    let taxes = runningDailyTotal * taxRate
+    XCTAssertEqual(taxes.roundedAmount, Decimal(string: "16.92")!)
+    runningDailyTotal += taxes
+    XCTAssertEqual(runningDailyTotal.roundedAmount, 204.90)
+
+    // apply flat fee
+    runningDailyTotal += flatFranchiseFee
+    XCTAssertEqual(runningDailyTotal.roundedAmount, 210.58)
+
+    // calculate week total
+    let weekRateTotal = runningDailyTotal * 7
+    XCTAssertEqual(weekRateTotal.roundedAmount, 1_474.06)
+
+    // calculate commission
+    let commission = weekRateTotal * 0.10
+    XCTAssertEqual(commission.roundedAmount, 147.41)
+
+    let totalPrice = weekRateTotal + commission
+    XCTAssertEqual(totalPrice.roundedAmount, 1_621.46)
+
+    // Decimal validation
+    let expectedResult: Decimal = {
+      let basePrice = roomDailyRate.exactAmount
+      let discount = basePrice * 0.06
+      let tax = (basePrice - discount) * 0.09
+      let dayPrice = basePrice - discount + tax + 5.68
+      let weekPrice = dayPrice * 7
+      let commission = weekPrice * 0.10
+      return weekPrice + commission
+    }()
+    XCTAssertEqual(expectedResult, 1_621.4622116)
+
+    XCTAssertEqual(totalPrice, _New_USD(exactAmount: expectedResult))
+  }
+}

--- a/Tests/CurrencyTests/Currency+StringRepresentationTests.swift
+++ b/Tests/CurrencyTests/Currency+StringRepresentationTests.swift
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Currency
+import XCTest
+
+final class CurrencyStringRepresentationTests: XCTestCase {
+  let sampleDollar = _New_USD(300.8)
+  let sampleYen    = _New_JPY(400.98)
+}
+
+// MARK: Reflection Description
+
+extension CurrencyStringRepresentationTests {
+  func test_reflectionRepresentation_includesIdentifierName() {
+    XCTAssertTrue(String(reflecting: self.sampleDollar).contains(_New_USD.alphabeticCode))
+    XCTAssertTrue(String(reflecting: self.sampleYen).contains(_New_JPY.alphabeticCode))
+  }
+
+  func test_reflectionRepresentation_includesExactAmount() {
+    XCTAssertTrue(String(reflecting: self.sampleDollar).contains(self.sampleDollar.exactAmount.description))
+    XCTAssertTrue(String(reflecting: self.sampleYen).contains(self.sampleYen.exactAmount.description))
+  }
+
+  func test_customMirror_children_includes_exactAmount() throws {
+    let child = try XCTUnwrap(
+      Mirror(reflecting: self.sampleDollar)
+        .children
+        .first(where: { $0.label == "exactAmount" })
+    )
+    XCTAssertEqual(child.value as? Decimal, self.sampleDollar.exactAmount)
+  }
+
+  func test_customMirror_children_includes_minorUnits() throws {
+    let child = try XCTUnwrap(
+      Mirror(reflecting: self.sampleDollar)
+        .children
+        .first(where: { $0.label == "minorUnits" })
+    )
+    XCTAssertEqual(child.value as? CurrencyMinorUnitRepresentation, self.sampleDollar.minorUnits)
+  }
+
+  func test_customMirror_children_includes_descriptor() throws {
+    let child = try XCTUnwrap(
+      Mirror(reflecting: self.sampleDollar)
+        .children
+        .first(where: { $0.label == "descriptor" })
+    )
+    XCTAssertNotNil(child.value as? _New_USD.Type)
+  }
+}
+
+// MARK: String Description
+
+extension CurrencyStringRepresentationTests {
+  func test_description_includesIdentifierName() {
+    XCTAssertTrue(self.sampleDollar.description.contains(_New_USD.alphabeticCode))
+    XCTAssertTrue(self.sampleYen.description.contains(_New_JPY.alphabeticCode))
+  }
+
+  func test_description_includesExactAmount() {
+    XCTAssertTrue(self.sampleDollar.description.contains(self.sampleDollar.exactAmount.description))
+    XCTAssertTrue(self.sampleYen.description.contains(self.sampleYen.exactAmount.description))
+  }
+}
+
+// MARK: Debug Description
+
+extension CurrencyStringRepresentationTests {
+  func test_debugDescription_includesIdentifierName() {
+    XCTAssertTrue(self.sampleDollar.debugDescription.contains(_New_USD.alphabeticCode))
+    XCTAssertTrue(self.sampleYen.debugDescription.contains(_New_JPY.alphabeticCode))
+  }
+
+  func test_debugDescription_includesExactAmount() {
+    XCTAssertTrue(self.sampleDollar.debugDescription.contains(self.sampleDollar.exactAmount.description))
+    XCTAssertTrue(self.sampleYen.debugDescription.contains(self.sampleYen.exactAmount.description))
+  }
+
+  func test_debugDescription_includesMinorUnits() {
+    XCTAssertTrue(self.sampleDollar.debugDescription.contains(self.sampleDollar.minorUnits.description))
+    XCTAssertTrue(self.sampleYen.debugDescription.contains(self.sampleYen.minorUnits.description))
+  }
+}
+
+// MARK: Playground Description
+
+extension CurrencyStringRepresentationTests {
+  func test_playgroundDescription_matchesDebugDescription() {
+    XCTAssertEqual(self.sampleDollar.playgroundDescription as? String, self.sampleDollar.debugDescription)
+    XCTAssertEqual(self.sampleYen.playgroundDescription as? String, self.sampleYen.debugDescription)
+  }
+}
+
+// MARK: String Interpolation
+
+extension CurrencyStringRepresentationTests {
+  func test_stringInterpolation_forLocale_whenNilValue_usesNilDescription_whenProvided() {
+    let value: _New_USD? = nil
+    XCTAssertEqual("\(localize: value, nilDescription: #function)", #function)
+  }
+
+  func test_stringInterpolation_withFormatter_whenNilValue_usesNilDescription_whenProvided() {
+    let value: _New_USD? = nil
+    XCTAssertEqual("\(localize: value, with: NumberFormatter(), nilDescription: #function)", #function)
+  }
+
+  func test_stringInterpolation_forLocale_whenNilValue_hasDefaultDescription() {
+    let value: _New_USD? = nil
+    XCTAssertEqual("\(localize: value)", "nil")
+  }
+
+  func test_stringInterpolation_withFormatter_whenNilValue_hasDefaultDescription() {
+    let value: _New_USD? = nil
+    XCTAssertEqual("\(localize: value, with: NumberFormatter())", "nil")
+  }
+
+  func test_stringInterpolation_forLocale_usesLocale_whenProvided() {
+    let pounds = _New_GBP(14928.789)
+    XCTAssertEqual("\(localize: pounds, for: .init(identifier: "en_UK"))", "£14,928.79")
+    XCTAssertEqual("\(localize: pounds, for: .init(identifier: "de_DE"))", "14.928,79 £")
+  }
+
+  func test_stringInterpolation_withFormatter_usesFormatter_whenProvided() {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.currencyGroupingSeparator = " "
+    formatter.currencyDecimalSeparator = "'"
+
+    let pounds = _New_GBP(14928.018)
+    formatter.currencyCode = _New_GBP.alphabeticCode
+    XCTAssertEqual("\(localize: pounds, with: formatter)", "£14 928'02")
+
+    let expectedYenResult = "¥4 001"
+    let yen = _New_JPY(4000.9)
+    formatter.currencyCode = _New_JPY.alphabeticCode
+    XCTAssertEqual("\(localize: yen, with: formatter)", expectedYenResult)
+  }
+
+  func test_stringInterpolation_forLocale_usesDefaultLocale() {
+    XCTAssertEqual("\(localize: _New_USD(4321.389))", "$4,321.39")
+  }
+}
+
+// MARK: LocalizedString
+
+extension CurrencyStringRepresentationTests {
+  func test_localizedString_forLocale_usesDefaultLocale() {
+    XCTAssertEqual(_New_USD(4321.389).localizedString(), "$4,321.39")
+  }
+
+  func test_localizedString_forLocale_usesProvidedLocale() {
+    let pounds = _New_GBP(14928.789)
+    XCTAssertEqual(pounds.localizedString(for: .init(identifier: "en_UK")), "£14,928.79")
+    XCTAssertEqual(pounds.localizedString(for: .init(identifier: "de_DE")), "14.928,79 £")
+  }
+
+  func test_localizedString_withFormatter_usesProvidedFormatter() {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.currencyGroupingSeparator = " "
+    formatter.currencyDecimalSeparator = "'"
+
+    let pounds = _New_GBP(14928.018)
+    formatter.currencyCode = _New_GBP.alphabeticCode
+    XCTAssertEqual(pounds.localizedString(using: formatter), "£14 928'02")
+
+    let expectedYenResult = "¥4 001"
+    let yen = _New_JPY(4000.9)
+    formatter.currencyCode = _New_JPY.alphabeticCode
+    XCTAssertEqual(yen.localizedString(using: formatter), expectedYenResult)
+  }
+}

--- a/Tests/CurrencyTests/CurrencyDescriptorTests.swift
+++ b/Tests/CurrencyTests/CurrencyDescriptorTests.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Currency
+import XCTest
+
+final class CurrencyDescriptorTests: XCTestCase { }
+
+// MARK: Minor Units
+
+extension CurrencyDescriptorTests {
+  func test_minorUnitsCoefficient_forExactAmount_shiftsLeftByMinorUnits() {
+    XCTAssertEqual(_New_JPY.minorUnitsCoefficient(for: .exactAmount), 1)
+    XCTAssertEqual(_New_XTS.minorUnitsCoefficient(for: .exactAmount), 10)
+    XCTAssertEqual(_New_USD.minorUnitsCoefficient(for: .exactAmount), 100)
+    XCTAssertEqual(_New_KWD.minorUnitsCoefficient(for: .exactAmount), 1000)
+  }
+
+  func test_minorUnitsCoefficient_forMinorUnits_shiftsRightByMinorUnits() {
+    XCTAssertEqual(_New_JPY.minorUnitsCoefficient(for: .minorUnits), 1)
+    XCTAssertEqual(_New_XTS.minorUnitsCoefficient(for: .minorUnits), 0.1)
+    XCTAssertEqual(_New_USD.minorUnitsCoefficient(for: .minorUnits), 0.01)
+    XCTAssertEqual(_New_KWD.minorUnitsCoefficient(for: .minorUnits), 0.001)
+  }
+}

--- a/Tests/CurrencyTests/CurrencyTests.swift
+++ b/Tests/CurrencyTests/CurrencyTests.swift
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Currency
+import XCTest
+
+final class CurrencyTests: XCTestCase { }
+
+// MARK: Initialization
+
+extension CurrencyTests {
+  func test_init_exactAmount_doesNotModifyValue() {
+    func assertInit(amount: Decimal, for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+      XCTAssertEqual(
+        currencyType.init(exactAmount: amount).exactAmount,
+        amount,
+        file: file, line: line
+      )
+    }
+
+    assertInit(amount: 30.23, for: _New_USD.self)
+    assertInit(amount: -208.001, for: _New_USD.self)
+    assertInit(amount: .nan, for: _New_USD.self)
+
+    assertInit(amount: 100.23, for: _New_JPY.self)
+    assertInit(amount: -39820, for: _New_JPY.self)
+    assertInit(amount: .nan, for: _New_JPY.self)
+
+    assertInit(amount: 02838.29708, for: _New_KWD.self)
+    assertInit(amount: -300.87, for: _New_KWD.self)
+    assertInit(amount: .nan, for: _New_KWD.self)
+  }
+
+  func test_init_minorUnits_correctlyConvertsToDecimal() {
+    XCTAssertEqual(_New_USD(minorUnits: 100), _New_USD(exactAmount: 1.0))
+    XCTAssertEqual(_New_USD(minorUnits: 101), _New_USD(exactAmount: 1.01))
+    XCTAssertEqual(_New_USD(minorUnits: 50011), _New_USD(exactAmount: 500.11))
+  }
+}
+
+// MARK: Minor Units Representation
+
+extension CurrencyTests {
+  func test_0MinorUnits_representationIsCorrect() {
+    XCTAssertEqual(_New_JPY.zero.minorUnits, .zero)
+    XCTAssertEqual(_New_JPY(exactAmount: 10.01).minorUnits, 10)
+    XCTAssertEqual(_New_JPY(exactAmount: 100).minorUnits, 100)
+  }
+
+  func test_1MinorUnits_representationIsCorrect() {
+    XCTAssertEqual(_New_XTS.zero.minorUnits, .zero)
+    XCTAssertEqual(_New_XTS(exactAmount: 10.01).minorUnits, 100)
+    XCTAssertEqual(_New_XTS(exactAmount: 100).minorUnits, 1000)
+  }
+
+  func test_2MinorUnits_representationIsCorrect() {
+    XCTAssertEqual(_New_USD.zero.minorUnits, .zero)
+    XCTAssertEqual(_New_USD(exactAmount: 10.01).minorUnits, 1001)
+    XCTAssertEqual(_New_USD(exactAmount: 100).minorUnits, 10000)
+  }
+
+  func test_3MinorUnits_representationIsCorrect() {
+    XCTAssertEqual(_New_KWD.zero.minorUnits, .zero)
+    XCTAssertEqual(_New_KWD(exactAmount: 10.01).minorUnits, 10010)
+    XCTAssertEqual(_New_KWD(exactAmount: 100).minorUnits, 100000)
+  }
+}
+
+// MARK: Equatable, Hashable, Comparable
+
+extension CurrencyTests {
+  struct TestCurrency: Currency, CurrencyDescriptor {
+    static var name: String = "TestCurrency"
+    static var alphabeticCode: String = "TC"
+    static var numericCode: UInt16 = .max
+    static var minorUnits: UInt8 = 2
+
+    let exactAmount: Decimal
+  }
+
+  func test_equatable_whenDifferentDescriptors_isFalse() {
+    XCTAssertFalse(_New_USD(exactAmount: .nan) == TestCurrency(exactAmount: .nan))
+  }
+
+  func test_equatable_whenSameDescriptors_andSameExactAmount_isTrue() {
+    XCTAssertTrue(TestCurrency(exactAmount: .nan) == TestCurrency(exactAmount: .nan))
+  }
+
+  func test_equatable_whenSameDescriptors_andDifferentExactAmount_isFalse() {
+    XCTAssertFalse(TestCurrency(exactAmount: .nan) == TestCurrency(exactAmount: .zero))
+    XCTAssertFalse(TestCurrency(exactAmount: 30.01) == TestCurrency(exactAmount: 30.001))
+    XCTAssertFalse(TestCurrency(exactAmount: 30.01) == TestCurrency(exactAmount: 30.012))
+    XCTAssertFalse(TestCurrency(exactAmount: 30.01) == TestCurrency(exactAmount: 30.019))
+  }
+
+  func test_comparable_whenDifferentDescriptors_comparesDescriptorPrimaryCode() {
+    XCTAssertTrue(TestCurrency(exactAmount: 30) < _New_USD(exactAmount: 30))
+    XCTAssertTrue(_New_KWD(exactAmount: 30) < TestCurrency(exactAmount: 30))
+  }
+
+  func test_comparable_whenSameDescriptors_comparesExactAmount() {
+    XCTAssertTrue(TestCurrency(exactAmount: 30) < TestCurrency(exactAmount: 30.01))
+  }
+
+  func test_hashable_whenDifferentDescriptors_hasDifferentHashValues() {
+    let first = self._hash_currency(TestCurrency(exactAmount: 30))
+    let second = self._hash_currency(_New_USD(exactAmount: 30))
+
+    XCTAssertNotEqual(first, second)
+  }
+
+  func test_hashable_whenSameDescriptors_andSameExactAmount_hasSameHashValues() {
+    let first = self._hash_currency(TestCurrency(exactAmount: 30))
+    let second = self._hash_currency(TestCurrency(exactAmount: 30))
+
+    XCTAssertEqual(first, second)
+  }
+
+  func test_hashable_whenSameDescriptors_andDifferentExactAmount_hasDifferentHasValues() {
+    let first = self._hash_currency(TestCurrency(exactAmount: 30))
+    let second = self._hash_currency(TestCurrency(exactAmount: 30.01))
+
+    XCTAssertNotEqual(first, second)
+  }
+
+  private func _hash_currency(_ currency: some Currency) -> Int {
+    var hasher = Hasher()
+    hasher.combine(currency)
+    return hasher.finalize()
+  }
+}
+
+// MARK: Example Usage

--- a/Tests/CurrencyTests/Sequence+CurrencyTests.swift
+++ b/Tests/CurrencyTests/Sequence+CurrencyTests.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCurrency open source project
+//
+// Copyright (c) 2024 SwiftCurrency project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCurrency project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Currency
+import XCTest
+
+final class SequenceCurrencyTests: XCTestCase { }
+
+// MARK: Sum
+
+extension SequenceCurrencyTests {
+  func test_sum() {
+    let amounts: [_New_USD] = [304.98, 19.02]
+    let sumTotal = amounts.sum()
+    XCTAssertEqual(sumTotal.roundedAmount, 324)
+  }
+
+  func test_sum_withWhereClause() {
+    let amounts: [_New_USD] = [304.98, 9.02, 30.21]
+    let sumTotal = amounts.sum(where: { $0.exactAmount > 20 })
+    XCTAssertEqual(sumTotal.roundedAmount, 335.19)
+  }
+
+  func test_sum_withMap() {
+    let prices: [_New_USD] = [3, 2.99, 5.98]
+    let totalTaxes = prices.sum { $0 * Decimal(0.09) }
+    XCTAssertEqual(totalTaxes.roundedAmount, 1.08)
+  }
+}


### PR DESCRIPTION
Motivation:

Decimal provides the correct semantics for representing currency as it guarantees representation of values exactly, as opposed to floating point representations that may be incorrect. This also allows for correct representations of fractional values during arithmetic, delaying rounding until the user needs it to avoid "penny shaving".

In addition, the new implementation has much tighter semantics of how its expected to use a `Currency` value, by not conforming to `AdditiveArithmetic` and not providing the ability to multiply or divide two `Currency` values

Modifications:
- Add: New plain protocol `Currency`
- Add: Tests for new protocols and extensions
- Change: Code generation of ISO currencies to include copies conforming to the new `Currency` protocol
- Rename: `CurrencyMetadata` to `CurrencyDescriptor`
- Remove: `distributedProportionally` algorithm from `Currency`

Result:
The `Currency` type is more correct, with better ergonomics for usage in a wider array of contexts, while avoiding common pitfalls.
