### PR TITLE
Re-write CurrencyMint implementation for new Currency protocol

### DIFF
--- a/Sources/Currency/CurrencyMint.swift
+++ b/Sources/Currency/CurrencyMint.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2020 SwiftCurrency project authors
+// Copyright (c) 2024 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -51,7 +51,7 @@ extension CurrencyMint {
 /// A generator object that supports creation of type-safe currencies by their alphabetic or numeric code identifiers.
 public final class CurrencyMint {
   /// A closure that receives a currency identifier and finds a matching concrete currency type.
-  public typealias IdentifierLookup = (CurrencyIdentifier) -> AnyCurrency.Type?
+  public typealias IdentifierLookup = (CurrencyIdentifier) -> (any Currency.Type)?
 
   /// Returns a shared currency generator that only provides ISO 4217 defined currencies.
   public static var standard: CurrencyMint { return .init() }
@@ -68,8 +68,8 @@ public final class CurrencyMint {
 
   /// Creates an instance that will always resolves the provided currency type when ISO 4217 specification lookup fails.
   /// - Parameter defaultCurrency: The default currency type to provide when a currency's identifier is not found in the ISO 4217 specification.
-  public init<T: CurrencyProtocol>(defaultCurrency: T.Type) {
-    self.fallbackLookup = { _ in return defaultCurrency }
+  public init(defaultCurrency: (some Currency).Type) {
+    self.fallbackLookup = { _ in defaultCurrency }
   }
 
   private let fallbackLookup: IdentifierLookup
@@ -83,7 +83,7 @@ extension CurrencyMint {
   ///   - identifier: The identifier of the currency to be created.
   ///   - minorUnits: The quantity of minor units the currency value should represent. The default is `0`.
   /// - Returns: An instance of a currency that matches the provided identifier with the desired amount; otherwise `nil`.
-  public func make(identifier: CurrencyIdentifier, minorUnits value: Int64 = .zero) -> AnyCurrency? {
+  public func make(identifier: CurrencyIdentifier, minorUnits value: Int64 = .zero) -> (any Currency)? {
     guard let currencyType = self.lookup(identifier) else { return nil }
     return currencyType.init(minorUnits: value)
   }
@@ -91,15 +91,15 @@ extension CurrencyMint {
   /// Creates a currency value for the provided identifier.
   /// - Parameters:
   ///   - identifier: The identifier of the currency to be created.
-  ///   - amount: The amount the currency value should represent.
+  ///   - value: The amount the currency value should represent.
   /// - Returns: An instance of a currency that matches the provided identifier with the desired amount; otherwise `nil`.
-  public func make(identifier: CurrencyIdentifier, amount value: Decimal) -> AnyCurrency? {
+  public func make(identifier: CurrencyIdentifier, exactAmount value: Decimal) -> (any Currency)? {
     guard let currencyType = self.lookup(identifier) else { return nil }
-    return currencyType.init(amount: value)
+    return currencyType.init(exactAmount: value)
   }
 
-  private func lookup(_ identifier: CurrencyIdentifier) -> AnyCurrency.Type? {
-    var typeFound: AnyCurrency.Type? = nil
+  private func lookup(_ identifier: CurrencyIdentifier) -> (any Currency.Type)? {
+    var typeFound: (any Currency.Type)? = nil
     switch identifier {
     case let .alphaCode(value): typeFound = CurrencyMint.lookup(byAlphaCode: value)
     case let .numericCode(value): typeFound = CurrencyMint.lookup(byNumCode: value)

--- a/Sources/ISOStandardCodegen/MintISOSupportGeneration.swift
+++ b/Sources/ISOStandardCodegen/MintISOSupportGeneration.swift
@@ -43,7 +43,7 @@ fileprivate func makeIdentifierLookupSnippet(
     .map {
       let patternMatch = type == .numeric ? $0.identifiers.numeric.description : "\"\($0.identifiers.alphabetic)\""
 
-      return "case \(patternMatch): return \($0.identifiers.alphabetic).self"
+      return "case \(patternMatch): return _New_\($0.identifiers.alphabetic).self"
     }
     .joined(separator: "\n\t\t")
 
@@ -51,7 +51,7 @@ fileprivate func makeIdentifierLookupSnippet(
   let parameterType = type == .numeric ? "UInt16" : "String"
 
   return """
-  internal static func lookup(\(argumentName) code: \(parameterType)) -> AnyCurrency.Type? {
+  internal static func lookup(\(argumentName) code: \(parameterType)) -> (any Currency.Type)? {
   \t\tswitch code {
   \t\t\(casesSnippet)
 

--- a/Tests/CurrencyTests/CurrencyMintTests.swift
+++ b/Tests/CurrencyTests/CurrencyMintTests.swift
@@ -15,82 +15,118 @@
 import Currency
 import XCTest
 
-final class CurrencyMintTests: XCTestCase {
-  func testLookupByString_passes() {
-    let pounds = CurrencyMint.standard.make(identifier: "GBP")
-    XCTAssertTrue(pounds is GBP)
-    XCTAssertEqual(pounds?.amount, .zero)
-  }
-  
-  func testLookupByString_withAmount() {
+final class CurrencyMintTests: XCTestCase { }
+
+// MARK: Fallback Lookup
+
+extension CurrencyMintTests {
+  func test_defaultLookup_whenLookupFails_returnsNil() {
     let mint = CurrencyMint.standard
-    
-    let yen = mint.make(identifier: "JPY", amount: 302.98)
-    XCTAssertTrue(yen is JPY)
-    XCTAssertEqual(yen?.amount, 303)
-    
-    let usd = mint.make(identifier: "USD", minorUnits: 549)
-    XCTAssertTrue(usd is USD)
-    XCTAssertEqual(usd?.amount, 5.49)
-  }
-  
-  func testLookupByString_fails() {
-    let darseks = CurrencyMint.standard.make(identifier: "KED", amount: 30.23)
+
+    var darseks = mint.make(identifier: .fakeCurrencyAlphaCode, exactAmount: 30.23)
+    XCTAssertNil(darseks)
+
+    darseks = CurrencyMint.standard.make(identifier: .fakeCurrencyNumericCode, minorUnits: 300)
     XCTAssertNil(darseks)
   }
-  
-  func testLookupByNum_passes() {
-    let euros = CurrencyMint.standard.make(identifier: 978)
-    XCTAssertTrue(euros is EUR)
-    XCTAssertEqual(euros?.amount, .zero)
-  }
-  
-  func testLookupByNum_withAmount() {
-    let mint = CurrencyMint.standard
-    
-    let pesos = mint.make(identifier: 484, amount: 3098.9823)
-    XCTAssertTrue(pesos is MXN)
-    XCTAssertEqual(pesos?.amount, 3098.98)
-    
-    let omanis = mint.make(identifier: 512, minorUnits: 198239)
-    XCTAssertTrue(omanis is OMR)
-    XCTAssertEqual(omanis?.amount, 198.239)
-  }
-  
-  func testLookupByNum_fails() {
-    let darseks = CurrencyMint.standard.make(identifier: 666)
-    XCTAssertNil(darseks)
-  }
-  
-  func testDefaultCurrency() {
-    let mint = CurrencyMint(defaultCurrency: USD.self)
-    let money = mint.make(identifier: "KED")
-    XCTAssertTrue(money is USD)
-  }
-  
-  func testFallbackLookup() {
-    struct KED: CurrencyProtocol, CurrencyMetadata {
+
+  func test_withFallbackLookup_whenLookupFails_callsFallbackLookup() {
+    struct KED: Currency, CurrencyMetadata {
       static var name: String { return "Klingon Darseks" }
       static var alphabeticCode: String { return "KED" }
       static var numericCode: UInt16 { return 666 }
       static var minorUnits: UInt8 { return 3 }
-      
-      var minorUnits: Int64
 
-      public init<T : BinaryInteger>(minorUnits: T) { self.minorUnits = .init(minorUnits) }
+      let exactAmount: Decimal
     }
-    
+
+    let expectation = self.expectation(description: "fallback lookup closure to be called")
+    expectation.expectedFulfillmentCount = 2
+
     let mint = CurrencyMint(fallbackLookup: { identifier in
+      expectation.fulfill()
+
       guard identifier == .alphaCode("KED") || identifier == .numericCode(666) else { return nil }
       return KED.self
     })
-    
-    let d1 = mint.make(identifier: "KED", amount: 30.239)
+
+    let expectedAmount = Decimal(string: "30.239")!
+    let d1 = mint.make(identifier: "KED", exactAmount: expectedAmount)
     XCTAssertTrue(d1 is KED)
-    XCTAssertEqual(d1 as? KED, 30.239)
-    
-    let d2 = mint.make(identifier: 666, minorUnits: d1?.minorUnits ?? .zero)
+
+    let d2 = mint.make(identifier: 666, minorUnits: .zero)
     XCTAssertTrue(d2 is KED)
-    XCTAssertEqual(d2?.minorUnits, 30239)
+
+    self.waitForExpectations(timeout: 1)
   }
+
+  func test_withDefaultCurrencyLookup_whenLookupFails_returnsDefaultCurrency() {
+    let mint = CurrencyMint(defaultCurrency: _New_USD.self)
+
+    var money = mint.make(identifier: .fakeCurrencyAlphaCode)
+    XCTAssertTrue(money is _New_USD)
+
+    money = mint.make(identifier: .fakeCurrencyNumericCode)
+    XCTAssertTrue(money is _New_USD)
+  }
+}
+
+// MARK: Factory Methods
+
+extension CurrencyMintTests {
+  func test_make_withMinorUnits_returnsISOCurrency() {
+    let mint = CurrencyMint.standard
+
+    let pounds = mint.make(identifier: .poundsAlphaCode, minorUnits: .zero)
+    XCTAssertTrue(pounds is _New_GBP)
+
+    let yen = mint.make(identifier: .yenNumericCode, minorUnits: 300)
+    XCTAssertTrue(yen is _New_JPY)
+
+    let euros = CurrencyMint.standard.make(identifier: 978, minorUnits: .zero)
+    XCTAssertTrue(euros is _New_EUR)
+  }
+
+  func test_make_withAmount_returnsISOCurrency() {
+    let mint = CurrencyMint.standard
+
+    let pounds = mint.make(identifier: .poundsAlphaCode, exactAmount: .zero)
+    XCTAssertTrue(pounds is _New_GBP)
+
+    let yen = mint.make(identifier: .yenNumericCode, exactAmount: 192.8)
+    XCTAssertTrue(yen is _New_JPY)
+
+    let euros = CurrencyMint.standard.make(identifier: 978, exactAmount: .zero)
+    XCTAssertTrue(euros is _New_EUR)
+  }
+
+  func test_make_withMinorUnits_matchesMinorUnits() {
+    let mint = CurrencyMint.standard
+
+    let pounds = mint.make(identifier: .poundsAlphaCode, minorUnits: 549)
+    XCTAssertEqual(pounds?.minorUnits, 549)
+
+    let yen = mint.make(identifier: .yenNumericCode, minorUnits: 302)
+    XCTAssertEqual(yen?.minorUnits, 302)
+  }
+
+  func test_make_withAmount_matchesExactAmount() {
+    let mint = CurrencyMint.standard
+
+    let pounds = mint.make(identifier: .poundsAlphaCode, exactAmount: .zero)
+    XCTAssertEqual(pounds?.exactAmount, .zero)
+
+    let yen = mint.make(identifier: .yenNumericCode, exactAmount: 302.98)
+    XCTAssertEqual(yen?.exactAmount, 302.98)
+  }
+}
+
+// MARK: Test Helpers
+
+extension CurrencyMint.CurrencyIdentifier {
+  fileprivate static var fakeCurrencyAlphaCode: Self { "KED" } // "darseks"
+  fileprivate static var fakeCurrencyNumericCode: Self { 666 }
+
+  fileprivate static var poundsAlphaCode: Self { .alphaCode(_New_GBP.alphabeticCode) }
+  fileprivate static var yenNumericCode: Self { .numericCode(_New_JPY.numericCode) }
 }


### PR DESCRIPTION
Motivation:

CurrencyMint is a useful abstraction that allows creation of instances of Currency types dynamically, such as from API responses. The existing implementation doesn't correctly allow working with existential instances. There are also language features available in 5.7+ to better express things in the type system.

Modifications:

- Change: `CurrencyMint` to work with `any Currency` instead of `AnyCurrency`
- Change: Codgen to return the new `Currency` conforming types rather than `AnyCurrency`
- Change: Unit tests to be smaller units that better cover the different behaviors of the type

Result:

`CurrencyMint` is more flexible in the type system and plays better with modern Swift language features.