### PR TITLE
Rename Currency protocol to CurrencyValue

### DIFF
--- a/Sources/Currency/CurrencyMint.swift
+++ b/Sources/Currency/CurrencyMint.swift
@@ -51,7 +51,7 @@ extension CurrencyMint {
 /// A generator object that supports creation of type-safe currencies by their alphabetic or numeric code identifiers.
 public final class CurrencyMint {
   /// A closure that receives a currency identifier and finds a matching concrete currency type.
-  public typealias IdentifierLookup = (CurrencyIdentifier) -> (any Currency.Type)?
+  public typealias IdentifierLookup = (CurrencyIdentifier) -> (any CurrencyValue.Type)?
 
   /// Returns a shared currency generator that only provides ISO 4217 defined currencies.
   public static var standard: CurrencyMint { return .init() }
@@ -68,7 +68,7 @@ public final class CurrencyMint {
 
   /// Creates an instance that will always resolves the provided currency type when ISO 4217 specification lookup fails.
   /// - Parameter defaultCurrency: The default currency type to provide when a currency's identifier is not found in the ISO 4217 specification.
-  public init(defaultCurrency: (some Currency).Type) {
+  public init(defaultCurrency: (some CurrencyValue).Type) {
     self.fallbackLookup = { _ in defaultCurrency }
   }
 
@@ -83,7 +83,7 @@ extension CurrencyMint {
   ///   - identifier: The identifier of the currency to be created.
   ///   - minorUnits: The quantity of minor units the currency value should represent. The default is `0`.
   /// - Returns: An instance of a currency that matches the provided identifier with the desired amount; otherwise `nil`.
-  public func make(identifier: CurrencyIdentifier, minorUnits value: Int64 = .zero) -> (any Currency)? {
+  public func make(identifier: CurrencyIdentifier, minorUnits value: Int64 = .zero) -> (any CurrencyValue)? {
     guard let currencyType = self.lookup(identifier) else { return nil }
     return currencyType.init(minorUnits: value)
   }
@@ -93,13 +93,13 @@ extension CurrencyMint {
   ///   - identifier: The identifier of the currency to be created.
   ///   - value: The amount the currency value should represent.
   /// - Returns: An instance of a currency that matches the provided identifier with the desired amount; otherwise `nil`.
-  public func make(identifier: CurrencyIdentifier, exactAmount value: Decimal) -> (any Currency)? {
+  public func make(identifier: CurrencyIdentifier, exactAmount value: Decimal) -> (any CurrencyValue)? {
     guard let currencyType = self.lookup(identifier) else { return nil }
     return currencyType.init(exactAmount: value)
   }
 
-  private func lookup(_ identifier: CurrencyIdentifier) -> (any Currency.Type)? {
-    var typeFound: (any Currency.Type)? = nil
+  private func lookup(_ identifier: CurrencyIdentifier) -> (any CurrencyValue.Type)? {
+    var typeFound: (any CurrencyValue.Type)? = nil
     switch identifier {
     case let .alphaCode(value): typeFound = CurrencyMint.lookup(byAlphaCode: value)
     case let .numericCode(value): typeFound = CurrencyMint.lookup(byNumCode: value)

--- a/Sources/Currency/CurrencyValue+Algorithms.swift
+++ b/Sources/Currency/CurrencyValue+Algorithms.swift
@@ -16,7 +16,7 @@ import Foundation
 
 // MARK: Even Distribution
 
-extension Currency {
+extension CurrencyValue {
   /// Distributes the current amount into a set number of parts as evenly as possible.
   ///
   /// After splitting the amount evenly, any remainder will be given to the first value in the result collection.

--- a/Sources/Currency/CurrencyValue+Arithmetic.swift
+++ b/Sources/Currency/CurrencyValue+Arithmetic.swift
@@ -16,7 +16,7 @@ import Foundation
 
 // MARK: Identity
 
-extension Currency {
+extension CurrencyValue {
   /// The zero value.
   ///
   /// Zero is the identity element for addition. For any value,
@@ -39,7 +39,7 @@ extension Currency {
 
 // MARK: Addition
 
-extension Currency {
+extension CurrencyValue {
   // perhaps convert to minor units, multiply, then convert back to decimal?
 
   public static func +(lhs: Self, rhs: Self) -> Self {
@@ -99,7 +99,7 @@ extension Currency {
 
 // MARK: Subtraction
 
-extension Currency {
+extension CurrencyValue {
   // perhaps convert to minor units, multiply, then convert back to decimal?
 
   public static func -(lhs: Self, rhs: Self) -> Self {
@@ -156,7 +156,7 @@ extension Currency {
 
 //  MARK: Multiplication
 
-extension Currency {
+extension CurrencyValue {
   // perhaps convert to minor units, multiply, then convert back to decimal?
   // let result = Double(lhs.minorUnits * rhs.minorUnits) / pow(10, Double(Self.metadata.minorUnits))
 
@@ -198,7 +198,7 @@ extension Currency {
 
 // MARK: Division
 
-extension Currency {
+extension CurrencyValue {
   // perhaps convert to minor units, multiply, then convert back to decimal?
   // let quotent = Double(lhs.minorUnits) / .init(rhs.minorUnits)
   // let result = quotent * pow(10, Double(Self.metadata.minorUnits))

--- a/Sources/Currency/CurrencyValue+StringRepresentation.swift
+++ b/Sources/Currency/CurrencyValue+StringRepresentation.swift
@@ -25,7 +25,7 @@ import class Foundation.NSDecimalNumber
 
 // MARK: CustomStringConvertible
 
-extension Currency {
+extension CurrencyValue {
   public var description: String { "\(self.exactAmount) \(Self.descriptor.alphabeticCode)"}
   public var debugDescription: String {
     "\(Self.descriptor.alphabeticCode)(exact: \(self.exactAmount.description), minorUnits: \(self.minorUnits)"
@@ -61,8 +61,8 @@ extension String.StringInterpolation {
   ///   - value: The value to localize. If the value is `nil`, then the `nilDescription` will be used.
   ///   - locale: The Locale to localize the value for. The default is `.current`, ig. the runtime environment's Locale.
   ///   - nilDescription: The optional description to use when the `value` is `nil`.
-  public mutating func appendInterpolation<C: Currency>(
-    localize value: C?,
+  public mutating func appendInterpolation<Currency: CurrencyValue>(
+    localize value: Currency?,
     for locale: Locale = .current,
     nilDescription: String = "nil"
   ) {
@@ -71,7 +71,7 @@ extension String.StringInterpolation {
     let formatter = NumberFormatter()
     formatter.numberStyle = .currency
     formatter.locale = locale
-    formatter.currencyCode = C.descriptor.alphabeticCode
+    formatter.currencyCode = Currency.descriptor.alphabeticCode
 
     self.appendInterpolation(localize: value, with: formatter, nilDescription: nilDescription)
   }
@@ -101,8 +101,8 @@ extension String.StringInterpolation {
   ///   - value: The value to localize. If the value is `nil`, then the `nilDescription` will be used.
   ///   - formatter: The pre-configured formatter to use.
   ///   - nilDescription: The optional description to use when the `value` is `nil`.
-  public mutating func appendInterpolation<C: Currency>(
-    localize value: C?,
+  public mutating func appendInterpolation<Currency: CurrencyValue>(
+    localize value: Currency?,
     with formatter: NumberFormatter,
     nilDescription: String = "nil"
   ) {
@@ -117,7 +117,7 @@ extension String.StringInterpolation {
   }
 }
 
-extension Currency {
+extension CurrencyValue {
   /// Creates a string representation of the currency value, localized to a particular locale.
   ///
   ///       let usd = USD(30.03)

--- a/Sources/Currency/CurrencyValue.swift
+++ b/Sources/Currency/CurrencyValue.swift
@@ -26,7 +26,7 @@ import func Foundation.NSDecimalRound
 /// For example, as the USD uses 1/100 for its minor unit, with the value `USD(1.0)`, `minorUnits` will be the value `100`.
 ///
 /// _Equality comparisons and most arithmetic operations use this value._
-public protocol Currency:
+public protocol CurrencyValue:
   CustomStringConvertible, CustomDebugStringConvertible, CustomPlaygroundDisplayConvertible,
   CustomReflectable,
   Comparable, Hashable,
@@ -82,7 +82,7 @@ public protocol Currency:
 
 // MARK: Defaults
 
-extension Currency {
+extension CurrencyValue {
   public var minorUnits: CurrencyMinorUnitRepresentation {
     let scaledAmount = self.exactAmount * Self.descriptor.minorUnitsCoefficient(for: .exactAmount)
     return .init(scaledAmount.int64Value)
@@ -103,14 +103,14 @@ extension Currency {
   }
 }
 
-extension Currency where Self: CurrencyDescriptor {
+extension CurrencyValue where Self: CurrencyDescriptor {
   public static var descriptor: CurrencyDescriptor.Type { Self.self }
 }
 
 // MARK: Equatable
 
-extension Currency {
-  public static func ==<Other: Currency>(lhs: Self, rhs: Other) -> Bool {
+extension CurrencyValue {
+  public static func ==<Other: CurrencyValue>(lhs: Self, rhs: Other) -> Bool {
     guard Self.descriptor == Other.descriptor else { return false }
     return lhs.exactAmount == rhs.exactAmount
   }
@@ -118,8 +118,8 @@ extension Currency {
 
 // MARK: Comparable
 
-extension Currency {
-  public static func < <Other: Currency>(lhs: Self, rhs: Other) -> Bool {
+extension CurrencyValue {
+  public static func < <Other: CurrencyValue>(lhs: Self, rhs: Other) -> Bool {
     guard Self.descriptor == Other.descriptor else {
       return Self.descriptor.alphabeticCode < Other.descriptor.alphabeticCode
     }
@@ -129,7 +129,7 @@ extension Currency {
 
 // MARK: Hashable
 
-extension Currency {
+extension CurrencyValue {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ObjectIdentifier(Self.descriptor))
     hasher.combine(self.exactAmount)
@@ -138,7 +138,7 @@ extension Currency {
 
 // MARK: CustomReflectable
 
-extension Currency {
+extension CurrencyValue {
   public var customMirror: Mirror {
     return .init(self, children: [
       "exactAmount": self.exactAmount,
@@ -150,7 +150,7 @@ extension Currency {
 
 // MARK: Literal Representations
 
-extension Currency {
+extension CurrencyValue {
   public init(floatLiteral value: Double) {
     self.init(exactAmount: Decimal(value))
   }

--- a/Sources/Currency/Extensions/Sequence+Currency.swift
+++ b/Sources/Currency/Extensions/Sequence+Currency.swift
@@ -14,7 +14,7 @@
 
 // MARK: Sum
 
-extension Sequence where Element: Currency {
+extension Sequence where Element: CurrencyValue {
   /// Returns the sum total of all amounts in the sequence.
   ///
   /// For example:

--- a/Sources/ISOStandardCodegen/Codegen+CurrencyDefinitions.swift
+++ b/Sources/ISOStandardCodegen/Codegen+CurrencyDefinitions.swift
@@ -58,7 +58,7 @@ private func makeTypeDefinitions(from definitions: [CurrencyDefinition]) -> [Str
 
     return """
     \(summary)
-    public struct \(definition.identifiers.alphabetic): Currency, CurrencyDescriptor {
+    public struct \(definition.identifiers.alphabetic): CurrencyValue, CurrencyDescriptor {
       public static var name: String { "\(definition.name)" }
       public static var alphabeticCode: String { "\(definition.identifiers.alphabetic)" }
       public static var numericCode: UInt16 { \(definition.identifiers.numeric) }

--- a/Sources/ISOStandardCodegen/Codegen+MintLookup.swift
+++ b/Sources/ISOStandardCodegen/Codegen+MintLookup.swift
@@ -53,7 +53,7 @@ fileprivate func makeIdentifierLookupSnippet(
   let parameterType = type == .numeric ? "UInt16" : "String"
 
   return """
-  internal static func lookup(\(argumentName) code: \(parameterType)) -> (any Currency.Type)? {
+  internal static func lookup(\(argumentName) code: \(parameterType)) -> (any CurrencyValue.Type)? {
   \t\tswitch code {
   \t\t\(casesSnippet)
 

--- a/Tests/CurrencyTests/CurrencyMintTests.swift
+++ b/Tests/CurrencyTests/CurrencyMintTests.swift
@@ -31,7 +31,7 @@ extension CurrencyMintTests {
   }
 
   func test_withFallbackLookup_whenLookupFails_callsFallbackLookup() {
-    struct KED: Currency, CurrencyMetadata {
+    struct KED: CurrencyValue, CurrencyMetadata {
       static var name: String { return "Klingon Darseks" }
       static var alphabeticCode: String { return "KED" }
       static var numericCode: UInt16 { return 666 }

--- a/Tests/CurrencyTests/CurrencyValue+AlgorithmsTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+AlgorithmsTests.swift
@@ -15,11 +15,11 @@
 import Currency
 import XCTest
 
-final class CurrencyAlgorithmsTests: XCTestCase { }
+final class CurrencyValueAlgorithmsTests: XCTestCase { }
 
 // MARK: Distributed Evenly
 
-extension CurrencyAlgorithmsTests {
+extension CurrencyValueAlgorithmsTests {
   func test_distributedEvenly_with0_orNegative_NumParts_returnsEmptyResult() {
     let value = USD(5)
     XCTAssertTrue(value.distributedEvenly(intoParts: 0).isEmpty)
@@ -63,10 +63,10 @@ extension CurrencyAlgorithmsTests {
     )
   }
 
-  private func run_distributedEvenlyTest<C: Currency>(
-    for currency: C,
+  private func run_distributedEvenlyTest<Currency: CurrencyValue>(
+    for currency: Currency,
     numParts count: Int,
-    expectedResults: [C],
+    expectedResults: [Currency],
     file: StaticString = #file,
     line: UInt = #line
   ) {

--- a/Tests/CurrencyTests/CurrencyValue+ArithmeticTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+ArithmeticTests.swift
@@ -15,11 +15,11 @@
 import Currency
 import XCTest
 
-final class CurrencyArithmeticTests: XCTestCase { }
+final class CurrencyValueArithmeticTests: XCTestCase { }
 
 // MARK: Identity
 
-extension CurrencyArithmeticTests {
+extension CurrencyValueArithmeticTests {
   func test_zero_equalsDecimalZero() {
     XCTAssertTrue(USD.zero.exactAmount == .zero)
     XCTAssertTrue(JPY.zero.exactAmount == .zero)
@@ -27,7 +27,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_negated_correctlyInvertsValues() {
-    func assertNegationIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertNegationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let positive = currencyType.init(exactAmount: 30.03)
       XCTAssertEqual(
         positive.negated(),
@@ -53,9 +53,9 @@ extension CurrencyArithmeticTests {
 
 // MARK: Addition
 
-extension CurrencyArithmeticTests {
+extension CurrencyValueArithmeticTests {
   func test_addition_withSelf_isCorrect() {
-    func assertAdditionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first + currencyType.init(exactAmount: 30.01),
@@ -88,7 +88,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_addition_withBinaryInteger_isCorrect() {
-    func assertAdditionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first + (30 as Int),
@@ -121,7 +121,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_addition_withDecimal_isCorrect() {
-    func assertAdditionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first + (30 as Decimal),
@@ -156,9 +156,9 @@ extension CurrencyArithmeticTests {
 
 // MARK: Subtraction
 
-extension CurrencyArithmeticTests {
+extension CurrencyValueArithmeticTests {
   func test_subtraction_withSelf_isCorrect() {
-    func assertSubtractionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first - currencyType.init(exactAmount: 30.01),
@@ -191,7 +191,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_subtraction_withBinaryInteger_isCorrect() {
-    func assertSubtractionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first - (30 as Int),
@@ -224,7 +224,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_subtraction_withDecimal_isCorrect() {
-    func assertSubtractionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first - (30 as Decimal),
@@ -259,9 +259,9 @@ extension CurrencyArithmeticTests {
 
 // MARK: Multiplication
 
-extension CurrencyArithmeticTests {
+extension CurrencyValueArithmeticTests {
   func test_multiplication_withBinaryInteger_isCorrect() {
-    func assertMultiplicationIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertMultiplicationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first * (3 as Int),
@@ -294,7 +294,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_multiplication_withDecimal_isCorrect() {
-    func assertMultiplicationIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertMultiplicationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first * (5.25 as Decimal),
@@ -329,9 +329,9 @@ extension CurrencyArithmeticTests {
 
 // MARK: Division
 
-extension CurrencyArithmeticTests {
+extension CurrencyValueArithmeticTests {
   func test_division_withBinaryInteger_isCorrect() {
-    func assertDivisionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertDivisionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first / (3 as Int),
@@ -364,7 +364,7 @@ extension CurrencyArithmeticTests {
   }
 
   func test_division_withDecimal_isCorrect() {
-    func assertDivisionIsCorrect(for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertDivisionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300)
       XCTAssertEqual(
         first / (2.4 as Decimal),
@@ -399,7 +399,7 @@ extension CurrencyArithmeticTests {
 
 // MARK: Example Usage
 
-extension CurrencyArithmeticTests {
+extension CurrencyValueArithmeticTests {
   func test_sampleUSDTransaction_withTaxRate_isNotMissingPennies() {
     /*
      original price    taxes (9%)        result

--- a/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
@@ -15,14 +15,14 @@
 import Currency
 import XCTest
 
-final class CurrencyStringRepresentationTests: XCTestCase {
+final class CurrencyValueStringRepresentationTests: XCTestCase {
   let sampleDollar = USD(300.8)
   let sampleYen    = JPY(400.98)
 }
 
 // MARK: Reflection Description
 
-extension CurrencyStringRepresentationTests {
+extension CurrencyValueStringRepresentationTests {
   func test_reflectionRepresentation_includesIdentifierName() {
     XCTAssertTrue(String(reflecting: self.sampleDollar).contains(USD.alphabeticCode))
     XCTAssertTrue(String(reflecting: self.sampleYen).contains(JPY.alphabeticCode))
@@ -63,7 +63,7 @@ extension CurrencyStringRepresentationTests {
 
 // MARK: String Description
 
-extension CurrencyStringRepresentationTests {
+extension CurrencyValueStringRepresentationTests {
   func test_description_includesIdentifierName() {
     XCTAssertTrue(self.sampleDollar.description.contains(USD.alphabeticCode))
     XCTAssertTrue(self.sampleYen.description.contains(JPY.alphabeticCode))
@@ -77,7 +77,7 @@ extension CurrencyStringRepresentationTests {
 
 // MARK: Debug Description
 
-extension CurrencyStringRepresentationTests {
+extension CurrencyValueStringRepresentationTests {
   func test_debugDescription_includesIdentifierName() {
     XCTAssertTrue(self.sampleDollar.debugDescription.contains(USD.alphabeticCode))
     XCTAssertTrue(self.sampleYen.debugDescription.contains(JPY.alphabeticCode))
@@ -96,7 +96,7 @@ extension CurrencyStringRepresentationTests {
 
 // MARK: Playground Description
 
-extension CurrencyStringRepresentationTests {
+extension CurrencyValueStringRepresentationTests {
   func test_playgroundDescription_matchesDebugDescription() {
     XCTAssertEqual(self.sampleDollar.playgroundDescription as? String, self.sampleDollar.debugDescription)
     XCTAssertEqual(self.sampleYen.playgroundDescription as? String, self.sampleYen.debugDescription)
@@ -105,7 +105,7 @@ extension CurrencyStringRepresentationTests {
 
 // MARK: String Interpolation
 
-extension CurrencyStringRepresentationTests {
+extension CurrencyValueStringRepresentationTests {
   func test_stringInterpolation_forLocale_whenNilValue_usesNilDescription_whenProvided() {
     let value: USD? = nil
     XCTAssertEqual("\(localize: value, nilDescription: #function)", #function)
@@ -155,7 +155,7 @@ extension CurrencyStringRepresentationTests {
 
 // MARK: LocalizedString
 
-extension CurrencyStringRepresentationTests {
+extension CurrencyValueStringRepresentationTests {
   func test_localizedString_forLocale_usesDefaultLocale() {
     XCTAssertEqual(USD(4321.389).localizedString(), "$4,321.39")
   }

--- a/Tests/CurrencyTests/CurrencyValueTests.swift
+++ b/Tests/CurrencyTests/CurrencyValueTests.swift
@@ -15,13 +15,13 @@
 import Currency
 import XCTest
 
-final class CurrencyTests: XCTestCase { }
+final class CurrencyValueTests: XCTestCase { }
 
 // MARK: Initialization
 
-extension CurrencyTests {
+extension CurrencyValueTests {
   func test_init_exactAmount_doesNotModifyValue() {
-    func assertInit(amount: Decimal, for currencyType: (some Currency).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertInit(amount: Decimal, for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(
         currencyType.init(exactAmount: amount).exactAmount,
         amount,
@@ -51,7 +51,7 @@ extension CurrencyTests {
 
 // MARK: Minor Units Representation
 
-extension CurrencyTests {
+extension CurrencyValueTests {
   func test_0MinorUnits_representationIsCorrect() {
     XCTAssertEqual(JPY.zero.minorUnits, .zero)
     XCTAssertEqual(JPY(exactAmount: 10.01).minorUnits, 10)
@@ -79,8 +79,8 @@ extension CurrencyTests {
 
 // MARK: Equatable, Hashable, Comparable
 
-extension CurrencyTests {
-  struct TestCurrency: Currency, CurrencyDescriptor {
+extension CurrencyValueTests {
+  struct TestCurrency: CurrencyValue, CurrencyDescriptor {
     static var name: String = "TestCurrency"
     static var alphabeticCode: String = "TC"
     static var numericCode: UInt16 = .max
@@ -134,7 +134,7 @@ extension CurrencyTests {
     XCTAssertNotEqual(first, second)
   }
 
-  private func _hash_currency(_ currency: some Currency) -> Int {
+  private func _hash_currency(_ currency: some CurrencyValue) -> Int {
     var hasher = Hasher()
     hasher.combine(currency)
     return hasher.finalize()
@@ -143,23 +143,23 @@ extension CurrencyTests {
 
 // MARK: Example Usage
 
-extension CurrencyTests {
+extension CurrencyValueTests {
   func test_existential_mathCompiles() {
-    let value: any Currency = USD(minorUnits: 300)
+    let value: any CurrencyValue = USD(minorUnits: 300)
 
     XCTAssertTrue(value is USD)
     XCTAssertEqual(value.adding(3.5).exactAmount, 6.5)
   }
 
   func test_existential_isImplicitlyOpened() {
-    func someGenericContext(_ value: some Currency) -> Bool {
+    func someGenericContext(_ value: some CurrencyValue) -> Bool {
       return value is USD
     }
-    func someOtherGenericContext<C: Currency>(_ value: C) -> C {
+    func someOtherGenericContext<Currency: CurrencyValue>(_ value: Currency) -> Currency {
       return value + 3.5
     }
 
-    let value: any Currency = USD.zero
+    let value: any CurrencyValue = USD.zero
     XCTAssertTrue(someGenericContext(value))
     XCTAssertEqual(someOtherGenericContext(value).exactAmount, 3.5)
   }


### PR DESCRIPTION
Motivation:

Swift has a hard time disambiguating symbol references between modules and types when they share the same symbol name (eg. Currency as the module name and protocol), especially in downstream dependency chains when doing certain things.

The current name does not work when users are trying to write extensions or typealiases on the protocol, making the usability much more limited than intended.

Modifications:

- Rename: `Currency` protocol to `CurrencyValue`

Result:

Downstream users are now able to easily reference the core protocol in their own code.