### PR TITLE
Enforce CurrencyDescriptor equality for comparable with compiler

### DIFF
--- a/Sources/Currency/CurrencyValue.swift
+++ b/Sources/Currency/CurrencyValue.swift
@@ -116,10 +116,7 @@ extension CurrencyValue {
 // MARK: Comparable
 
 extension CurrencyValue {
-  public static func < <Other: CurrencyValue>(lhs: Self, rhs: Other) -> Bool {
-    guard Self.descriptor == Other.descriptor else {
-      return Self.descriptor.alphabeticCode < Other.descriptor.alphabeticCode
-    }
+  public static func <(lhs: Self, rhs: Self) -> Bool {
     return lhs.exactAmount < rhs.exactAmount
   }
 }

--- a/Tests/CurrencyTests/CurrencyValueTests.swift
+++ b/Tests/CurrencyTests/CurrencyValueTests.swift
@@ -104,11 +104,6 @@ extension CurrencyValueTests {
     XCTAssertFalse(TestCurrency(exactAmount: 30.01) == TestCurrency(exactAmount: 30.019))
   }
 
-  func test_comparable_whenDifferentDescriptors_comparesDescriptorPrimaryCode() {
-    XCTAssertTrue(TestCurrency(exactAmount: 30) < USD(exactAmount: 30))
-    XCTAssertTrue(KWD(exactAmount: 30) < TestCurrency(exactAmount: 30))
-  }
-
   func test_comparable_whenSameDescriptors_comparesExactAmount() {
     XCTAssertTrue(TestCurrency(exactAmount: 30) < TestCurrency(exactAmount: 30.01))
   }


### PR DESCRIPTION
Motivation:

As raised in pull request #40, the behavior of dynamically comparing two different `CurrencyValue` types first by their descriptor is unexpected behavior. This can cause confusion for end users with no way to work around the default behavior.

Modifications:

- Change: `Comparable` conformance to only support comparing two of the same distinct types with `Self` requirements

Result:

Developers will be forced to explicitly state their intention for comparing two separate `CurrencyValue` instances themselves, giving more clarity to the behavior and not surprising developers.