### PR TITLE
Provide instance level access to descriptor information

### DIFF
--- a/Sources/Currency/CurrencyValue.swift
+++ b/Sources/Currency/CurrencyValue.swift
@@ -34,7 +34,8 @@ public protocol CurrencyValue:
   AdditiveArithmetic
 {
   /// The information describing the currency.
-  static var descriptor: CurrencyDescriptor.Type { get }
+  @inlinable
+  static var descriptor: any CurrencyDescriptor.Type { get }
 
   /// The exact amount of money being represented,
   /// even if the value is fractional of what the currency uses for its minor units.
@@ -52,12 +53,20 @@ public protocol CurrencyValue:
 // MARK: Defaults
 
 extension CurrencyValue where Self: CurrencyDescriptor {
-  public static var descriptor: CurrencyDescriptor.Type { Self.self }
+  public static var descriptor: any CurrencyDescriptor.Type { Self.self }
 }
 
 // MARK: Extensions
 
 extension CurrencyValue {
+  /// The information describing the currency.
+  ///
+  /// This is primarily for use when working in type-erased contexts.
+  ///
+  /// When possible, prefer the static property ``descriptor-40dnd`` instead.
+  @inlinable
+  public var descriptor: any CurrencyDescriptor.Type { Self.descriptor }
+
   /// The amount represented as a whole number of the curreny's "minor units".
   ///
   /// For example, as the USD uses 1/100 for its minor unit,

--- a/Tests/CurrencyTests/CurrencyValueTests.swift
+++ b/Tests/CurrencyTests/CurrencyValueTests.swift
@@ -17,6 +17,15 @@ import XCTest
 
 final class CurrencyValueTests: XCTestCase { }
 
+// MARK: Descriptor
+
+extension CurrencyValueTests {
+  func test_instanceDescriptor_matchesStaticDescriptor() {
+    let value: any CurrencyValue = USD(3.01)
+    XCTAssertTrue(value.descriptor == USD.descriptor)
+  }
+}
+
 // MARK: Initialization
 
 extension CurrencyValueTests {


### PR DESCRIPTION
Motivation:

Sometimes developers are working in type-erased contexts where they can't directly refer to the name of the type of the `CurrencyValue` and need access to the descriptor.

In this cases, having an instance member property to provide the value is straight forward and convenient.

Modifications:

- Add: `descriptor` instance property to `CurrencyValue`
- Add: `@inlinable` annotations to both the static and instance member `descriptor` properties

Result:

Developers now have access to the `CurrencyValue` descriptor type either at the type or instance level.