### PR TITLE
Inject Locale on Localization tests

### DIFF
--- a/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
@@ -158,7 +158,12 @@ extension CurrencyValueStringRepresentationTests {
 
 extension CurrencyValueStringRepresentationTests {
   func test_localizedString_forLocale_usesDefaultLocale() {
-    XCTAssertEqual(USD(4321.389).localizedString(for: .init(identifier: "en_US")), "$4,321.39")
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.locale = .current
+    formatter.currencyCode = USD.alphabeticCode
+    let expectedOutput = formatter.string(for: Decimal(4321.389))
+    XCTAssertEqual(expectedOutput, USD(4321.389).localizedString())
   }
 
   func test_localizedString_forLocale_usesProvidedLocale() {
@@ -172,10 +177,10 @@ extension CurrencyValueStringRepresentationTests {
     formatter.numberStyle = .currency
     formatter.currencyGroupingSeparator = " "
     formatter.currencyDecimalSeparator = "'"
-
-    let pounds = GBP(14928.018)
     formatter.currencyCode = GBP.alphabeticCode
     formatter.locale = .init(identifier: "en_US")
+
+    let pounds = GBP(14928.018)
     XCTAssertEqual(pounds.localizedString(using: formatter), "£14 928'02")
 
     let expectedYenResult = "¥4 001"

--- a/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
@@ -150,7 +150,10 @@ extension CurrencyValueStringRepresentationTests {
   }
 
   func test_stringInterpolation_forLocale_usesDefaultLocale() {
-    XCTAssertEqual("\(localize: USD(4321.389), for: Locale(identifier: "en_US"))", "$4,321.39")
+    let formatter = self.defaultLocaleNumberFormatter
+    formatter.currencyCode = USD.alphabeticCode
+    let expectedOutput = formatter.string(for: Decimal(4321.389))
+    XCTAssertEqual("\(localize: USD(4321.389))", expectedOutput)
   }
 }
 
@@ -158,10 +161,9 @@ extension CurrencyValueStringRepresentationTests {
 
 extension CurrencyValueStringRepresentationTests {
   func test_localizedString_forLocale_usesDefaultLocale() {
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .currency
-    formatter.locale = .current
+    let formatter = self.defaultLocaleNumberFormatter
     formatter.currencyCode = USD.alphabeticCode
+    
     let expectedOutput = formatter.string(for: Decimal(4321.389))
     XCTAssertEqual(expectedOutput, USD(4321.389).localizedString())
   }
@@ -187,5 +189,14 @@ extension CurrencyValueStringRepresentationTests {
     let yen = JPY(4000.9)
     formatter.currencyCode = JPY.alphabeticCode
     XCTAssertEqual(yen.localizedString(using: formatter), expectedYenResult)
+  }
+}
+
+extension CurrencyValueStringRepresentationTests {
+  private var defaultLocaleNumberFormatter: NumberFormatter {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.locale = .current
+    return formatter
   }
 }

--- a/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+StringRepresentationTests.swift
@@ -137,6 +137,7 @@ extension CurrencyValueStringRepresentationTests {
     formatter.numberStyle = .currency
     formatter.currencyGroupingSeparator = " "
     formatter.currencyDecimalSeparator = "'"
+    formatter.locale = .init(identifier: "en_US")
 
     let pounds = GBP(14928.018)
     formatter.currencyCode = GBP.alphabeticCode
@@ -149,7 +150,7 @@ extension CurrencyValueStringRepresentationTests {
   }
 
   func test_stringInterpolation_forLocale_usesDefaultLocale() {
-    XCTAssertEqual("\(localize: USD(4321.389))", "$4,321.39")
+    XCTAssertEqual("\(localize: USD(4321.389), for: Locale(identifier: "en_US"))", "$4,321.39")
   }
 }
 
@@ -157,7 +158,7 @@ extension CurrencyValueStringRepresentationTests {
 
 extension CurrencyValueStringRepresentationTests {
   func test_localizedString_forLocale_usesDefaultLocale() {
-    XCTAssertEqual(USD(4321.389).localizedString(), "$4,321.39")
+    XCTAssertEqual(USD(4321.389).localizedString(for: .init(identifier: "en_US")), "$4,321.39")
   }
 
   func test_localizedString_forLocale_usesProvidedLocale() {
@@ -174,6 +175,7 @@ extension CurrencyValueStringRepresentationTests {
 
     let pounds = GBP(14928.018)
     formatter.currencyCode = GBP.alphabeticCode
+    formatter.locale = .init(identifier: "en_US")
     XCTAssertEqual(pounds.localizedString(using: formatter), "£14 928'02")
 
     let expectedYenResult = "¥4 001"


### PR DESCRIPTION
## Motivation:
*  Some unit tests were failing due to its dependency on the system Locale

## Modifications:
* Inject Locale dependency to avoid unit test flakiness

## Result:
![Screenshot 2025-01-07 at 6 33 54 PM](https://github.com/user-attachments/assets/f16774b3-4873-4bec-a989-a6f86fb31e51)
