### PR TITLE
Add explicit support for Swift 6

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-currency",
+    products: [
+        .library(name: "Currency", targets: ["Currency"]),
+    ],
+    dependencies: [],
+    targets: [
+      .target(
+        name: "Currency",
+        dependencies: [],
+        plugins: ["ISOStandardCodegenPlugin"]
+      ),
+      .testTarget(name: "CurrencyTests", dependencies: ["Currency"]),
+
+      .executableTarget(
+        name: "ISOStandardCodegen"
+      ),
+      .plugin(
+        name: "ISOStandardCodegenPlugin",
+        capability: .buildTool(),
+        dependencies: ["ISOStandardCodegen"]
+      )
+    ]
+)

--- a/Plugins/ISOStandardCodegenPlugin/plugin.swift
+++ b/Plugins/ISOStandardCodegenPlugin/plugin.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2024 SwiftCurrency project authors
+// Copyright (c) 2024-2025 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -16,27 +16,56 @@ import PackagePlugin
 
 @main
 struct ISOCurrencies: BuildToolPlugin {
-    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
-      let dataInputPath = context.package.directory.appending("ISO4217.json")
+  #if swift(>=6) && compiler(>=6)
+  func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+    let dataInputURL = context.package.directoryURL.appending(path: "ISO4217.json")
 
-      let currencyDefinitionPath = context.pluginWorkDirectory.appending("ISOCurrencies.swift")
-      let mintDefinitionPath = context.pluginWorkDirectory.appending("CurrencyMint+ISOCurrencyLookup.swift")
+    let currencyDefinitionURL = context.pluginWorkDirectoryURL.appending(path: "ISOCurrencies.swift")
+    let mintDefinitionURL = context.pluginWorkDirectoryURL.appending(path: "CurrencyMint+ISOCurrencyLookup.swift")
 
-      return [.buildCommand(
+    return [
+      .buildCommand(
         displayName: "Generating ISO Standard currency support code",
-        executable: try context.tool(named: "ISOStandardCodegen").path,
+        executable: try context.tool(named: "ISOStandardCodegen").url,
         arguments: [
-          dataInputPath.string,
-          currencyDefinitionPath.string,
-          mintDefinitionPath.string
+          dataInputURL.path(),
+          currencyDefinitionURL.path(),
+          mintDefinitionURL.path()
         ],
+        environment: [:],
         inputFiles: [
-          dataInputPath
+          dataInputURL
         ],
         outputFiles: [
-          currencyDefinitionPath,
-          mintDefinitionPath
+          currencyDefinitionURL,
+          mintDefinitionURL
         ]
-      )]
-    }
+      )
+    ]
+  }
+  #else
+  func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+    let dataInputPath = context.package.directory.appending("ISO4217.json")
+
+    let currencyDefinitionPath = context.pluginWorkDirectory.appending("ISOCurrencies.swift")
+    let mintDefinitionPath = context.pluginWorkDirectory.appending("CurrencyMint+ISOCurrencyLookup.swift")
+
+    return [.buildCommand(
+      displayName: "Generating ISO Standard currency support code",
+      executable: try context.tool(named: "ISOStandardCodegen").path,
+      arguments: [
+        dataInputPath.string,
+        currencyDefinitionPath.string,
+        mintDefinitionPath.string
+      ],
+      inputFiles: [
+        dataInputPath
+      ],
+      outputFiles: [
+        currencyDefinitionPath,
+        mintDefinitionPath
+      ]
+    )]
+  }
+  #endif
 }

--- a/Tests/CurrencyTests/CurrencyMintTests.swift
+++ b/Tests/CurrencyTests/CurrencyMintTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2020 SwiftCurrency project authors
+// Copyright (c) 2020-2025 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -30,7 +30,7 @@ extension CurrencyMintTests {
     XCTAssertNil(darseks)
   }
 
-  func test_withFallbackLookup_whenLookupFails_callsFallbackLookup() {
+  func test_withFallbackLookup_whenLookupFails_callsFallbackLookup() async {
     struct KED: CurrencyValue, CurrencyDescriptor {
       static var name: String { return "Klingon Darseks" }
       static var alphabeticCode: String { return "KED" }
@@ -57,7 +57,13 @@ extension CurrencyMintTests {
     let d2 = mint.make(identifier: 666, minorUnits: .zero)
     XCTAssertTrue(d2 is KED)
 
-    self.waitForExpectations(timeout: 1)
+#if swift(>=5.9)
+    await self.fulfillment(of: [expectation], timeout: 1)
+#else
+    DispatchQueue.main.sync {
+      self.waitForExpectations(timeout: 1)
+    }
+#endif
   }
 
   func test_withDefaultCurrencyLookup_whenLookupFails_returnsDefaultCurrency() {

--- a/Tests/CurrencyTests/CurrencyValue+AlgorithmsTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+AlgorithmsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2024 SwiftCurrency project authors
+// Copyright (c) 2024-2025 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -67,7 +67,7 @@ extension CurrencyValueAlgorithmsTests {
     for currency: Currency,
     numParts count: Int,
     expectedResults: [Currency],
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard count == expectedResults.count else {

--- a/Tests/CurrencyTests/CurrencyValue+ArithmeticTests.swift
+++ b/Tests/CurrencyTests/CurrencyValue+ArithmeticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2024 SwiftCurrency project authors
+// Copyright (c) 2024-2025 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -27,7 +27,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_negated_correctlyInvertsValues() {
-    func assertNegationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertNegationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let positive = currencyType.init(exactAmount: 30.03)
       XCTAssertEqual(
         positive.negated(),
@@ -55,7 +55,7 @@ extension CurrencyValueArithmeticTests {
 
 extension CurrencyValueArithmeticTests {
   func test_addition_withSelf_isCorrect() {
-    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first + currencyType.init(exactAmount: 30.01),
@@ -88,7 +88,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_addition_withBinaryInteger_isCorrect() {
-    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first + (30 as Int),
@@ -121,7 +121,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_addition_withDecimal_isCorrect() {
-    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertAdditionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first + (30 as Decimal),
@@ -158,7 +158,7 @@ extension CurrencyValueArithmeticTests {
 
 extension CurrencyValueArithmeticTests {
   func test_subtraction_withSelf_isCorrect() {
-    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first - currencyType.init(exactAmount: 30.01),
@@ -191,7 +191,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_subtraction_withBinaryInteger_isCorrect() {
-    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first - (30 as Int),
@@ -224,7 +224,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_subtraction_withDecimal_isCorrect() {
-    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertSubtractionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first - (30 as Decimal),
@@ -261,7 +261,7 @@ extension CurrencyValueArithmeticTests {
 
 extension CurrencyValueArithmeticTests {
   func test_multiplication_withBinaryInteger_isCorrect() {
-    func assertMultiplicationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertMultiplicationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first * (3 as Int),
@@ -294,7 +294,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_multiplication_withDecimal_isCorrect() {
-    func assertMultiplicationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertMultiplicationIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first * (5.25 as Decimal),
@@ -331,7 +331,7 @@ extension CurrencyValueArithmeticTests {
 
 extension CurrencyValueArithmeticTests {
   func test_division_withBinaryInteger_isCorrect() {
-    func assertDivisionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertDivisionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300.12)
       XCTAssertEqual(
         first / (3 as Int),
@@ -364,7 +364,7 @@ extension CurrencyValueArithmeticTests {
   }
 
   func test_division_withDecimal_isCorrect() {
-    func assertDivisionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertDivisionIsCorrect(for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       let first = currencyType.init(exactAmount: 300)
       XCTAssertEqual(
         first / (2.4 as Decimal),

--- a/Tests/CurrencyTests/CurrencyValueTests.swift
+++ b/Tests/CurrencyTests/CurrencyValueTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCurrency open source project
 //
-// Copyright (c) 2024 SwiftCurrency project authors
+// Copyright (c) 2024-2025 SwiftCurrency project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -30,7 +30,7 @@ extension CurrencyValueTests {
 
 extension CurrencyValueTests {
   func test_init_exactAmount_doesNotModifyValue() {
-    func assertInit(amount: Decimal, for currencyType: (some CurrencyValue).Type, file: StaticString = #file, line: UInt = #line) {
+    func assertInit(amount: Decimal, for currencyType: (some CurrencyValue).Type, file: StaticString = #filePath, line: UInt = #line) {
       XCTAssertEqual(
         currencyType.init(exactAmount: amount).exactAmount,
         amount,
@@ -90,10 +90,10 @@ extension CurrencyValueTests {
 
 extension CurrencyValueTests {
   struct TestCurrency: CurrencyValue, CurrencyDescriptor {
-    static var name: String = "TestCurrency"
-    static var alphabeticCode: String = "TC"
-    static var numericCode: UInt16 = .max
-    static var minorUnits: UInt8 = 2
+    static var name: String { "TestCurrency" }
+    static var alphabeticCode: String { "TC" }
+    static var numericCode: UInt16 { .max }
+    static var minorUnits: UInt8 { 2 }
 
     let exactAmount: Decimal
   }


### PR DESCRIPTION
Motivation:

Much of the ecosystem is starting to make the migration to Swift 6. Some even build with warnings as errors.

The current project has many deprecation warnings when compiling as Swift 6.

Modifications:

- Add: Swift 5.7 backwards support Package.swift
- Change: Usage of #file in tests to #filePath
- Change: Implementation of Codegen plugin to not use deprecated properties and methods

Result:

Existing users should not see any build changes, while those building with Swift 6 should be able to continue using the project with no issues