### PR TITLE
[CI] Increase test coverage for Swift 6.0-6.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,11 @@ jobs:
           - { xcode_version: "15.0.1", macos_version: 14 }
           - { xcode_version: "15.2", macos_version: 14 }
           - { xcode_version: "15.4", macos_version: 14 }
+          - { xcode_version: "16.1", macos_version: 14 }
+          - { xcode_version: "16.2", macos_version: 14 }
           - { xcode_version: "15.4", macos_version: 15 }
+          - { xcode_version: "16.1", macos_version: 15 }
+          - { xcode_version: "16.3", macos_version: 15 }
     runs-on: macos-${{ matrix.swift-config.macos_version }}
     name: Xcode ${{ matrix.swift-config.xcode_version }} - macOS ${{ matrix.swift-config.macos_version }} Tests
     steps:
@@ -61,6 +65,16 @@ jobs:
           - { version: "5.10", distro: jammy }
           - { version: "5.10", distro: mantic }
           - { version: "5.10", distro: centos7 }
+          - { version: "6.0.3", distro: bookworm }
+          - { version: "6.0.3", distro: amazonlinux2 }
+          - { version: "6.0.3", distro: rhel-ubi9 }
+          - { version: "6.0.3", distro: focal }
+          - { version: "6.0.3", distro: jammy }
+          - { version: "6.1.0", distro: bookworm }
+          - { version: "6.1.0", distro: amazonlinux2 }
+          - { version: "6.1.0", distro: rhel-ubi9 }
+          - { version: "6.1.0", distro: focal }
+          - { version: "6.1.0", distro: jammy }
     container: swift:${{ matrix.swift-config.version }}-${{ matrix.swift-config.distro }}
     name: Swift ${{ matrix.swift-config.version }} - ${{ matrix.swift-config.distro }} Tests
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos-test:
+  macos:
     if: ${{ !(github.event.pull_request.draft || false) }}
     strategy:
       fail-fast: false
@@ -22,7 +22,7 @@ jobs:
           - { xcode_version: "16.1", macos_version: 15 }
           - { xcode_version: "16.3", macos_version: 15 }
     runs-on: macos-${{ matrix.swift-config.macos_version }}
-    name: Xcode ${{ matrix.swift-config.xcode_version }} - macOS ${{ matrix.swift-config.macos_version }} Tests
+    name: Xcode ${{ matrix.swift-config.xcode_version }} - macOS ${{ matrix.swift-config.macos_version }}
     steps:
     - uses: actions/checkout@v4
     - name: Check Swift version
@@ -33,7 +33,7 @@ jobs:
     - name: Run tests
       run: swift test
 
-  linux-test:
+  linux:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
     strategy:
@@ -76,8 +76,8 @@ jobs:
           - { version: "6.1.0", distro: focal }
           - { version: "6.1.0", distro: jammy }
     container: swift:${{ matrix.swift-config.version }}-${{ matrix.swift-config.distro }}
-    name: Swift ${{ matrix.swift-config.version }} - ${{ matrix.swift-config.distro }} Tests
+    name: Swift ${{ matrix.swift-config.version }} - ${{ matrix.swift-config.distro }}
     steps:
     - uses: actions/checkout@v1
-    - name: Run tests
+    - name: Run ${{ matrix.swift-config.version }} - ${{ matrix.swift-config.distro }} Tests
       run: swift test


### PR DESCRIPTION
## Motivation

The project was updated for Swift 6 compilers, but the CI runners wasn't updated to validate those runtimes.

## Modifications

- Add: Swift 6 and 6.1 capable runners to the CI test matrices
- Change: Naming of jobs and steps for readability

## Result

End-users can have greater confidence in the library working on their desired runtime.